### PR TITLE
Exclude coverage-reports from SonarCloud scan

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -72,7 +72,7 @@ jobs:
             /d:sonar.host.url="https://sonarcloud.io" \
             /d:sonar.cs.vscoveragexml.reportsPaths="coverage-reports/**/coverage.xml" \
             /d:sonar.javascript.lcov.reportPaths="coverage/lcov.info" \
-            /d:sonar.exclusions="**/wwwroot/**,**/obj/**,**/bin/**,**/Migrations/**,**/*.razor.js" \
+            /d:sonar.exclusions="coverage-reports/**,**/wwwroot/**,**/obj/**,**/bin/**,**/Migrations/**,**/*.razor.js" \
             /d:sonar.coverage.exclusions="**/Migrations/**,**/*Tests/**,**/wwwroot/**,**/*.razor.js,**/Program.cs,**/Routes.razor,**/jest.config.js,**/playwright.config.ts,tests/e2e/**,**/*.tests.js,**/*.test.js,**/*.spec.js" \
             /d:sonar.test.exclusions="**/obj/**,**/bin/**"
           dotnet build --configuration Release --no-restore


### PR DESCRIPTION
This pull request makes a small update to the SonarCloud workflow configuration. The change adds the `coverage-reports/**` directory to the list of files and folders excluded from SonarCloud analysis, ensuring that coverage report files are not scanned as part of the code quality checks.