### PR TITLE
About Page

### DIFF
--- a/src/Neba.Website.Server/About/About.razor
+++ b/src/Neba.Website.Server/About/About.razor
@@ -1,0 +1,438 @@
+@page "/about"
+@using Neba.Api.Contracts.Sponsors
+@using Neba.Website.Server.Services
+@using Neba.Website.Server.Sponsors
+@rendermode @(new InteractiveServerRenderMode(prerender: false))
+
+@inject ApiExecutor ApiExecutor
+@inject ISponsorsApi SponsorsApi
+@inject ILogger<About> Logger
+
+<PageTitle>About NEBA</PageTitle>
+<HeadContent>
+    <meta name="description"
+          content="New England's premier amateur scratch bowling tournament series — run by bowlers for bowlers since 1963. Learn about our mission, format, rules, and sponsors." />
+</HeadContent>
+
+<div class="neba-space-y-6">
+
+    <!-- Page title -->
+    <div class="page-title-bar">
+        <div class="page-title-inner">
+            <h1>About NEBA</h1>
+            <p>New England's premier amateur scratch bowling tournament series, run by bowlers for bowlers since 1963.</p>
+        </div>
+    </div>
+
+    <!-- Stats row -->
+    <div class="grid grid-cols-3 gap-4">
+        <div class="neba-card text-center">
+            <div class="text-3xl font-bold text-[var(--neba-blue-700)] font-display">60+</div>
+            <div class="text-xs font-semibold uppercase tracking-widest text-[var(--neba-gray-500)] mt-1">Years</div>
+        </div>
+        <div class="neba-card text-center">
+            <div class="text-3xl font-bold text-[var(--neba-blue-700)] font-display">1,000+</div>
+            <div class="text-xs font-semibold uppercase tracking-widest text-[var(--neba-gray-500)] mt-1">Events Held</div>
+        </div>
+        <div class="neba-card text-center">
+            <div class="text-3xl font-bold text-[var(--neba-blue-700)] font-display">500+</div>
+            <div class="text-xs font-semibold uppercase tracking-widest text-[var(--neba-gray-500)] mt-1">Active Bowlers</div>
+        </div>
+    </div>
+
+    <!-- About + Mission -->
+    <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <div class="neba-card">
+            <h2 class="panel-heading">About NEBA</h2>
+            <p class="section-text">NEBA is America's longest-running USBC-sanctioned monthly scratch tournament. NEBA was formed in 1963 and celebrated its 50th anniversary in 2013. In 2023, NEBA celebrated its 1,000th event.</p>
+            <p class="section-text">NEBA tournaments are professionally managed and provide the best scratch competition in New England.</p>
+        </div>
+        <div class="neba-card">
+            <h2 class="panel-heading">Our Mission</h2>
+            <p class="section-text" style="font-style: italic; font-size: 0.95rem; line-height: 1.8;">New England's premier amateur scratch bowling tournament series, run by bowlers for bowlers, striving to foster competitive excellence and player development.</p>
+        </div>
+    </div>
+
+    <!-- Tournament Format -->
+    <div class="neba-panel">
+        <h2 class="panel-heading">Tournament Format</h2>
+        <div class="flex items-center gap-3 flex-wrap mt-1">
+            <div class="text-center">
+                <div class="text-2xl font-bold text-[var(--neba-blue-700)] font-display">5</div>
+                <div class="text-xs font-semibold uppercase tracking-wide text-[var(--neba-gray-500)] mt-0.5">Qualifying Games</div>
+            </div>
+            <span class="text-[var(--neba-gray-400)] text-lg">→</span>
+            <div class="text-center">
+                <div class="text-2xl font-bold text-[var(--neba-blue-700)] font-display">10</div>
+                <div class="text-xs font-semibold uppercase tracking-wide text-[var(--neba-gray-500)] mt-0.5">Lanes</div>
+            </div>
+            <span class="text-[var(--neba-gray-400)] text-lg">→</span>
+            <div class="text-center">
+                <div class="text-lg font-bold text-[var(--neba-blue-700)] font-display">1-Game</div>
+                <div class="text-xs font-semibold uppercase tracking-wide text-[var(--neba-gray-500)] mt-0.5">Match Play Finals</div>
+            </div>
+            <span class="text-[var(--neba-gray-400)] text-lg">→</span>
+            <div class="text-center">
+                <div class="text-lg font-bold text-[var(--neba-blue-700)] font-display">Single Elim</div>
+                <div class="text-xs font-semibold uppercase tracking-wide text-[var(--neba-gray-500)] mt-0.5">Head-to-Head</div>
+            </div>
+        </div>
+        <p class="section-text mt-4">
+            1 in 4.5 to 1 in 5 entries qualify for match play (1 in 6 entries from each squad guaranteed).
+            1 in 7 Seniors (age 50+) are guaranteed to qualify; additionally 1 in 7 Women and Super Seniors (age 60+)
+            are also guaranteed, based on at least 7 entries.
+        </p>
+        <div class="mt-4">
+            <p class="section-text font-semibold mb-2">Squad times</p>
+            <div class="flex gap-2 flex-wrap">
+                <span class="squad-time-badge">Saturday @@ 6:00 PM</span>
+                <span class="squad-time-badge">Sunday @@ 9:00 AM</span>
+                <span class="squad-time-badge">Sunday @@ 12:30 PM</span>
+            </div>
+            <p class="section-text mt-2 text-xs text-[var(--neba-gray-500)]">Special tournaments (non-champs, Tournament of Champions) may have different times.</p>
+        </div>
+        <p class="section-text mt-3"><strong>Lane patterns:</strong> Announced at least 7 days in advance.</p>
+    </div>
+
+    <!-- Qualifying Structure table -->
+    <div class="neba-panel">
+        <h2 class="panel-heading">Qualifying Structure</h2>
+        <div class="overflow-x-auto mt-3">
+            <table class="neba-table w-full text-sm">
+                <thead>
+                    <tr>
+                        <th class="text-left">Entries</th>
+                        <th>Qualifiers</th>
+                        <th class="text-left">Byes</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr><td>20 or fewer</td><td>4</td><td>None</td></tr>
+                    <tr><td>21–30</td><td>6</td><td>1st round qualifiers 1–2</td></tr>
+                    <tr><td>31–40</td><td>8</td><td>None</td></tr>
+                    <tr><td>41–60</td><td>12</td><td>1st round qualifiers 1–4</td></tr>
+                    <tr><td>61–80</td><td>16</td><td>None</td></tr>
+                    <tr><td>81–120</td><td>24</td><td>1st round qualifiers 1–8</td></tr>
+                    <tr><td>121–160</td><td>32</td><td>None</td></tr>
+                    <tr><td>161–200</td><td>40</td><td>1st round qualifiers 1–24</td></tr>
+                    <tr><td>201–240</td><td>48</td><td>1st round qualifiers 1–16</td></tr>
+                    <tr><td>241–280</td><td>56</td><td>1st round qualifiers 1–8</td></tr>
+                    <tr><td>281 or more</td><td>64</td><td>None</td></tr>
+                </tbody>
+            </table>
+        </div>
+    </div>
+
+    <!-- Eligibility, Entry Fees, Attire -->
+    <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+
+        <div class="neba-panel">
+            <h3 class="info-card-heading">Eligibility</h3>
+            <p class="section-text">Any PBA or PWBA member that has not won a PBA, PWBA, or PBA50 national tournament in the past five years (US Open and USBC Masters are exempt) or is not in the top 40 on the national PBA points list for the prior season.</p>
+            <p class="section-text mt-3">Any NEBA member in good standing who wins a national title and maintains their NEBA membership can continue to compete in NEBA.</p>
+        </div>
+
+        <div class="neba-panel">
+            <h3 class="info-card-heading">Entry Fees</h3>
+            <p class="section-text font-semibold mb-2">Monthly tournaments</p>
+            <div class="fee-grid">
+                <div class="fee-row"><span class="fee-label">Regular events</span><span class="fee-amount">$100</span></div>
+                <div class="fee-row"><span class="fee-label">Special events</span><span class="fee-amount">$150</span></div>
+                <div class="fee-row"><span class="fee-label">Tournament of Champions</span><span class="fee-amount">$125</span></div>
+            </div>
+            <p class="section-text mt-3 text-xs text-[var(--neba-gray-500)]">Special events include Masters and Points Leaders tournaments.</p>
+            <p class="section-text mt-3 font-semibold mb-2">Membership</p>
+            <div class="fee-grid">
+                <div class="fee-row"><span class="fee-label">New member</span><span class="fee-amount">$25</span></div>
+                <div class="fee-row"><span class="fee-label">Renewal</span><span class="fee-amount">$25</span></div>
+                <div class="fee-row"><span class="fee-label">Non-member surcharge</span><span class="fee-amount">$15</span></div>
+                <div class="fee-row"><span class="fee-label">Guest (one time)</span><span class="fee-amount">$0</span></div>
+            </div>
+        </div>
+
+        <div class="neba-panel">
+            <h3 class="info-card-heading">Attire &amp; Payment</h3>
+            <p class="section-text font-semibold mb-1">Required</p>
+            <ul class="criteria-list">
+                <li>Polo-type or mock neck collar shirt</li>
+                <li>Pants or business casual shorts (zippers required)</li>
+                <li>Full name on back, 2–4 inch letters in contrasting color</li>
+                <li>Mock neck: all advertising must be permanently embroidered</li>
+            </ul>
+            <p class="section-text font-semibold mt-3 mb-1">Not allowed</p>
+            <ul class="criteria-list">
+                <li>Sweatpants, athletic shorts, yoga pants</li>
+                <li>Tattered, frayed, or clothing with holes</li>
+                <li>Hats, headbands, headphones, or earbuds</li>
+                <li>White shirts (previous NEBA champions only)</li>
+            </ul>
+            <div class="mt-3 pt-3 border-t border-[var(--neba-border)]">
+                <p class="section-text"><strong>Cash required</strong> at all NEBA tournaments.</p>
+                <p class="section-text text-xs text-[var(--neba-gray-500)] mt-1">New members may compete three times without a name on the back without penalty.</p>
+            </div>
+        </div>
+
+    </div>
+
+    <!-- Bowler of the Year Points System -->
+    <div class="neba-panel">
+        <h2 class="panel-heading">Bowler of the Year Points System</h2>
+        <div class="divide-y divide-[var(--neba-border)] mt-2">
+            <div class="flex items-center gap-3 py-2">
+                <span class="text-lg font-bold text-[var(--neba-blue-700)] font-display min-w-[3rem]">5</span>
+                <span class="section-text">Points for bowling</span>
+            </div>
+            <div class="flex items-center gap-3 py-2">
+                <span class="text-lg font-bold text-[var(--neba-blue-700)] font-display min-w-[3rem]">10</span>
+                <span class="section-text">Cash but do not qualify for match play (294 entries+)</span>
+            </div>
+            <div class="flex items-center gap-3 py-2">
+                <span class="text-lg font-bold text-[var(--neba-blue-700)] font-display min-w-[3rem]">15</span>
+                <span class="section-text">Match play — out in the first round</span>
+            </div>
+            <div class="flex items-center gap-3 py-2">
+                <span class="text-lg font-bold text-[var(--neba-blue-700)] font-display min-w-[3rem]">22</span>
+                <span class="section-text">Match play — out in the second round</span>
+            </div>
+            <div class="flex items-center gap-3 py-2">
+                <span class="text-lg font-bold text-[var(--neba-blue-700)] font-display min-w-[3rem]">30</span>
+                <span class="section-text">Match play — out in the third round</span>
+            </div>
+            <div class="flex items-center gap-3 py-2">
+                <span class="text-lg font-bold text-[var(--neba-blue-700)] font-display min-w-[3rem]">39</span>
+                <span class="section-text">Match play — out in the fourth round</span>
+            </div>
+            <div class="flex items-center gap-3 py-2">
+                <span class="text-lg font-bold text-[var(--neba-blue-700)] font-display min-w-[3rem]">49</span>
+                <span class="section-text">Match play — out in the fifth round</span>
+            </div>
+            <div class="flex items-center gap-3 py-2">
+                <span class="text-lg font-bold text-[var(--neba-blue-700)] font-display min-w-[3rem]">60</span>
+                <span class="section-text">Match play — out in the sixth round, or champion if fewer than 40 finalists</span>
+            </div>
+            <div class="flex items-center gap-3 py-2">
+                <span class="text-lg font-bold text-[var(--neba-blue-700)] font-display min-w-[3rem]">72</span>
+                <span class="section-text">Match play champion (40 or more finalists)</span>
+            </div>
+            <div class="flex items-center gap-3 py-2">
+                <span class="text-lg font-bold text-[var(--neba-blue-700)] font-display min-w-[3rem]">+5</span>
+                <span class="section-text">Bonus points awarded to high qualifiers</span>
+            </div>
+        </div>
+        <div class="mt-4 p-3 bg-[var(--neba-gray-050)] border border-[var(--neba-border)] rounded text-sm text-[var(--neba-gray-700)] leading-relaxed">
+            You do not get extra points for re-entering. If you bowl three times and do not make the cut, you get 5 points. If you bowl three times and make the cut, you get the position points.
+            <br /><br />
+            The match play point progression is: 15 base, then +7 first round, +8 second round, +9 third round, +10 fourth round, up to +12.
+            <br /><br />
+            <strong>Note:</strong> The point system is different for the Tournament of Champions and Doubles tournaments — see the rule book for details.
+        </div>
+    </div>
+
+    <!-- Board of Directors + Documents -->
+    <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+
+        <div class="neba-panel">
+            <h2 class="panel-heading">Board of Directors</h2>
+            <p class="section-text">NEBA is governed by a volunteer board of directors elected by the membership. The board sets organizational policy, oversees finances, and ensures every event meets the standard our members expect. For the full list of current officers and directors, see Article IV of the bylaws.</p>
+            <div class="mt-4">
+                <a href="/bylaws" class="neba-btn neba-btn-secondary inline-flex items-center gap-2 text-sm">
+                    View officers &amp; directors
+                    <svg width="14" height="14" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M9 5l7 7-7 7"/></svg>
+                </a>
+            </div>
+        </div>
+
+        <div class="neba-panel">
+            <h2 class="panel-heading">Documents &amp; Resources</h2>
+            <div class="flex flex-col gap-2 mt-1">
+                <div class="flex items-center justify-between gap-2 px-3 py-2 bg-[var(--neba-gray-050)] border border-[var(--neba-border)] rounded text-sm">
+                    <span class="font-medium text-[var(--neba-gray-800)]">Bylaws</span>
+                    <a href="/bylaws" class="inline-flex items-center gap-1 text-xs font-semibold text-[var(--neba-blue-700)] hover:text-[var(--neba-blue-500)]">
+                        View
+                        <svg width="12" height="12" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M9 5l7 7-7 7"/></svg>
+                    </a>
+                </div>
+                <div class="flex items-center justify-between gap-2 px-3 py-2 bg-[var(--neba-gray-050)] border border-[var(--neba-border)] rounded text-sm">
+                    <span class="font-medium text-[var(--neba-gray-800)]">Tournament Rules</span>
+                    <a href="/tournaments/rules" class="inline-flex items-center gap-1 text-xs font-semibold text-[var(--neba-blue-700)] hover:text-[var(--neba-blue-500)]">
+                        View
+                        <svg width="12" height="12" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M9 5l7 7-7 7"/></svg>
+                    </a>
+                </div>
+                <div class="flex items-center justify-between gap-2 px-3 py-2 bg-[var(--neba-gray-050)] border border-[var(--neba-border)] rounded text-sm">
+                    <span class="font-medium text-[var(--neba-gray-800)]">FAQ</span>
+                    <a href="/about/faq" class="inline-flex items-center gap-1 text-xs font-semibold text-[var(--neba-blue-700)] hover:text-[var(--neba-blue-500)]">
+                        View
+                        <svg width="12" height="12" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M9 5l7 7-7 7"/></svg>
+                    </a>
+                </div>
+                <div class="flex items-center justify-between gap-2 px-3 py-2 bg-[var(--neba-gray-050)] border border-[var(--neba-border)] rounded text-sm">
+                    <span class="font-medium text-[var(--neba-gray-800)]">Things to Know</span>
+                    <a href="/about/things-to-know" class="inline-flex items-center gap-1 text-xs font-semibold text-[var(--neba-blue-700)] hover:text-[var(--neba-blue-500)]">
+                        View
+                        <svg width="12" height="12" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M9 5l7 7-7 7"/></svg>
+                    </a>
+                </div>
+            </div>
+        </div>
+
+    </div>
+
+    <!-- Sponsors -->
+    <div class="neba-panel">
+        <div class="flex items-center justify-between gap-4 mb-4">
+            <h2 class="panel-heading mb-0">Our Sponsors</h2>
+            <a href="/sponsors" class="inline-flex items-center gap-1 text-sm font-semibold text-[var(--neba-blue-700)] hover:text-[var(--neba-blue-500)]">
+                View all sponsors
+                <svg width="14" height="14" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M9 5l7 7-7 7"/></svg>
+            </a>
+        </div>
+
+        @if (!string.IsNullOrWhiteSpace(_sponsorError))
+        {
+            <NebaAlert Severity="NotifySeverity.Error" Title="Error Loading Sponsors" Message="@_sponsorError" Dismissible="true"
+                       OnDismiss="@(() => _sponsorError = null)" />
+        }
+        else if (_sponsorsLoading)
+        {
+            <div aria-busy="true" aria-label="Loading sponsors" class="neba-space-y-4">
+                <div class="rounded-lg p-6 bg-[var(--neba-surface-high)] grid grid-cols-1 md:grid-cols-2 gap-6 items-center">
+                    <div class="space-y-3">
+                        <NebaSkeletonLoader Type="SkeletonType.Custom" Width="50%" Height="1.75rem" />
+                        <NebaSkeletonLoader Type="SkeletonType.Text" Rows="2" />
+                    </div>
+                    <NebaSkeletonLoader Type="SkeletonType.Custom" Width="100%" Height="140px" />
+                </div>
+                <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4">
+                    @for (var i = 0; i < 3; i++)
+                    {
+                        <div class="neba-card space-y-2">
+                            <div class="neba-skeleton h-16 w-full rounded"></div>
+                            <div class="neba-skeleton h-4 w-3/4"></div>
+                            <div class="neba-skeleton h-3 w-full"></div>
+                        </div>
+                    }
+                </div>
+            </div>
+        }
+        else
+        {
+            @if (TitleSponsor is not null)
+            {
+                <a href="/sponsors/@TitleSponsor.Slug"
+                   class="block rounded-lg p-6 bg-[var(--neba-color-primary-container)] text-white no-underline mb-5"
+                   aria-label="View details for @TitleSponsor.Name">
+                    <div class="grid grid-cols-1 md:grid-cols-2 gap-6 items-center">
+                        <div>
+                            <p class="text-xs font-semibold uppercase tracking-widest text-[var(--neba-blue-200)] mb-1">Title Sponsor</p>
+                            <h3 class="text-2xl font-bold mb-2">@TitleSponsor.Name</h3>
+                            @if (TitleSponsor.TagPhrase is not null)
+                            {
+                                <p class="text-[var(--neba-blue-200)] mb-2">@TitleSponsor.TagPhrase</p>
+                            }
+                            @if (TitleSponsor.Description is not null)
+                            {
+                                <p class="text-sm leading-relaxed opacity-90">@TitleSponsor.Description</p>
+                            }
+                        </div>
+                        <div class="flex justify-center md:justify-end">
+                            <div class="bg-white rounded-lg p-4 shadow-lg" style="transform: rotate(-2deg);">
+                                <img src="@(TitleSponsor.LogoUrl?.ToString() ?? "/images/neba-logo.png")"
+                                     alt="@TitleSponsor.Name logo"
+                                     class="max-h-32 object-contain" />
+                            </div>
+                        </div>
+                    </div>
+                </a>
+            }
+
+            @if (PremierSponsors.Any())
+            {
+                <div>
+                    <div class="flex items-center gap-3 mb-4">
+                        <h3 class="text-base font-bold text-[var(--neba-gray-800)] whitespace-nowrap">Premier Partners</h3>
+                        <hr class="flex-1 border-[var(--neba-border)]" />
+                    </div>
+                    <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4">
+                        @foreach (var sponsor in PremierSponsors)
+                        {
+                            <a href="/sponsors/@sponsor.Slug"
+                               class="neba-card sponsor-card-premier block"
+                               aria-label="Learn more about @sponsor.Name">
+                                <div class="h-20 flex items-center justify-center mb-3">
+                                    <img src="@(sponsor.LogoUrl?.ToString() ?? "/images/neba-logo.png")"
+                                         alt="@sponsor.Name logo"
+                                         class="max-h-16 object-contain" />
+                                </div>
+                                <h4 class="font-semibold text-[var(--neba-text)] mb-1">@sponsor.Name</h4>
+                                <div class="text-xs font-medium uppercase tracking-wide text-[var(--neba-blue-500)]">@sponsor.Category</div>
+                            </a>
+                        }
+                    </div>
+                </div>
+            }
+
+            @if (TitleSponsor is null && !PremierSponsors.Any())
+            {
+                <p class="section-text text-[var(--neba-gray-500)]">Sponsor information is not currently available.</p>
+            }
+        }
+    </div>
+
+    <!-- Reservations -->
+    <div class="neba-panel">
+        <h2 class="panel-heading">Reservations</h2>
+        <div class="flex flex-wrap items-start justify-between gap-6 mt-1">
+            <div>
+                <p class="section-text">Call to reserve your spot or fill out the form on the respective tournament page.</p>
+                <div class="text-2xl font-bold text-[var(--neba-blue-700)] font-display mt-2">
+                    <a href="tel:4135139508" class="hover:underline">(413) 513-9508</a>
+                </div>
+                <p class="section-text text-sm text-[var(--neba-gray-600)] mt-1">
+                    Deadline: <strong>Friday at 10:00 PM</strong> before the tournament
+                </p>
+            </div>
+            <a href="/tournaments" class="neba-btn neba-btn-primary inline-flex items-center gap-2">
+                View tournament schedule
+                <svg width="14" height="14" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M9 5l7 7-7 7"/></svg>
+            </a>
+        </div>
+    </div>
+
+</div>
+
+@code {
+    private List<SponsorSummaryViewModel> _sponsors = [];
+    private bool _sponsorsLoading = true;
+    private string? _sponsorError;
+
+    private SponsorSummaryViewModel? TitleSponsor =>
+        _sponsors.FirstOrDefault(s => s.Tier == "Title Sponsor");
+
+    private IEnumerable<SponsorSummaryViewModel> PremierSponsors =>
+        _sponsors
+            .Where(s => s.Tier == "Premier")
+            .OrderBy(s => s.Priority)
+            .ThenBy(s => s.Name);
+
+    protected override async Task OnInitializedAsync()
+    {
+        var result = await ApiExecutor.ExecuteAsync(
+            "Sponsors",
+            "ListActiveSponsors",
+            ct => SponsorsApi.ListActiveSponsorsAsync(ct));
+
+        _sponsorsLoading = false;
+
+        if (result.IsError)
+        {
+            _sponsorError = result.FirstError.Description;
+            return;
+        }
+
+        _sponsors = result.Value.Items
+            .Select(s => s.ToViewModel())
+            .Where(s => s.Tier is "Title Sponsor" or "Premier")
+            .ToList();
+    }
+}

--- a/src/Neba.Website.Server/About/About.razor
+++ b/src/Neba.Website.Server/About/About.razor
@@ -317,28 +317,28 @@
         }
         else
         {
-            @if (TitleSponsor is not null)
+            @if (_titleSponsor is not null)
             {
-                <a href="/sponsors/@TitleSponsor.Slug"
+                <a href="/sponsors/@_titleSponsor.Slug"
                    class="block rounded-lg p-6 bg-[var(--neba-color-primary-container)] text-white no-underline mb-5"
-                   aria-label="View details for @TitleSponsor.Name">
+                   aria-label="View details for @_titleSponsor.Name">
                     <div class="grid grid-cols-1 md:grid-cols-2 gap-6 items-center">
                         <div>
                             <p class="text-xs font-semibold uppercase tracking-widest text-[var(--neba-blue-200)] mb-1">Title Sponsor</p>
-                            <h3 class="text-2xl font-bold mb-2">@TitleSponsor.Name</h3>
-                            @if (TitleSponsor.TagPhrase is not null)
+                            <h3 id="about-title-sponsor-name" class="text-2xl font-bold mb-2">@_titleSponsor.Name</h3>
+                            @if (_titleSponsor.TagPhrase is not null)
                             {
-                                <p class="text-[var(--neba-blue-200)] mb-2">@TitleSponsor.TagPhrase</p>
+                                <p class="text-[var(--neba-blue-200)] mb-2">@_titleSponsor.TagPhrase</p>
                             }
-                            @if (TitleSponsor.Description is not null)
+                            @if (_titleSponsor.Description is not null)
                             {
-                                <p class="text-sm leading-relaxed opacity-90">@TitleSponsor.Description</p>
+                                <p class="text-sm leading-relaxed opacity-90">@_titleSponsor.Description</p>
                             }
                         </div>
                         <div class="flex justify-center md:justify-end">
                             <div class="bg-white rounded-lg p-4 shadow-lg" style="transform: rotate(-2deg);">
-                                <img src="@(TitleSponsor.LogoUrl?.ToString() ?? "/images/neba-logo.png")"
-                                     alt="@TitleSponsor.Name logo"
+                                <img src="@(_titleSponsor.LogoUrl?.ToString() ?? "/images/neba-logo.png")"
+                                     alt="@_titleSponsor.Name logo"
                                      class="max-h-32 object-contain" />
                             </div>
                         </div>
@@ -346,7 +346,7 @@
                 </a>
             }
 
-            @if (PremierSponsors.Any())
+            @if (_premierSponsors.Any())
             {
                 <div>
                     <div class="flex items-center gap-3 mb-4">
@@ -354,7 +354,7 @@
                         <hr class="flex-1 border-[var(--neba-border)]" />
                     </div>
                     <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4">
-                        @foreach (var sponsor in PremierSponsors)
+                        @foreach (var sponsor in _premierSponsors)
                         {
                             <a href="/sponsors/@sponsor.Slug"
                                class="neba-card sponsor-card-premier block"
@@ -372,7 +372,7 @@
                 </div>
             }
 
-            @if (TitleSponsor is null && !PremierSponsors.Any())
+            @if (_titleSponsor is null && !_premierSponsors.Any())
             {
                 <p class="section-text text-[var(--neba-gray-500)]">Sponsor information is not currently available.</p>
             }
@@ -386,7 +386,7 @@
             <div>
                 <p class="section-text">Call to reserve your spot or fill out the form on the respective tournament page.</p>
                 <div class="text-2xl font-bold text-[var(--neba-blue-700)] font-display mt-2">
-                    <a href="tel:4135139508" class="hover:underline">(413) 513-9508</a>
+                    <a href="tel:4135319508" class="hover:underline">(413) 531-9508</a>
                 </div>
                 <p class="section-text text-sm text-[var(--neba-gray-600)] mt-1">
                     Deadline: <strong>Friday at 10:00 PM</strong> before the tournament
@@ -402,18 +402,10 @@
 </div>
 
 @code {
-    private List<SponsorSummaryViewModel> _sponsors = [];
+    private SponsorSummaryViewModel? _titleSponsor;
+    private IReadOnlyList<SponsorSummaryViewModel> _premierSponsors = [];
     private bool _sponsorsLoading = true;
     private string? _sponsorError;
-
-    private SponsorSummaryViewModel? TitleSponsor =>
-        _sponsors.FirstOrDefault(s => s.Tier == "Title Sponsor");
-
-    private IEnumerable<SponsorSummaryViewModel> PremierSponsors =>
-        _sponsors
-            .Where(s => s.Tier == "Premier")
-            .OrderBy(s => s.Priority)
-            .ThenBy(s => s.Name);
 
     protected override async Task OnInitializedAsync()
     {
@@ -430,9 +422,12 @@
             return;
         }
 
-        _sponsors = result.Value.Items
-            .Select(s => s.ToViewModel())
-            .Where(s => s.Tier is "Title Sponsor" or "Premier")
+        var all = result.Value.Items.Select(s => s.ToViewModel()).ToList();
+        _titleSponsor = all.FirstOrDefault(s => s.Tier == "Title Sponsor");
+        _premierSponsors = all
+            .Where(s => s.Tier == "Premier")
+            .OrderBy(s => s.Priority)
+            .ThenBy(s => s.Name)
             .ToList();
     }
 }

--- a/src/Neba.Website.Server/About/About.razor.css
+++ b/src/Neba.Website.Server/About/About.razor.css
@@ -3,43 +3,6 @@
     font-family: var(--neba-font-display);
 }
 
-/* ── Page title bar ──────────────────────────────────────── */
-.page-title-bar {
-    background: linear-gradient(15deg, var(--neba-blue-brand) 0%, #3E4FD9 60%, #5563DD 100%);
-    padding: 2rem 2.5rem;
-    border-radius: var(--radius-xl);
-    color: #fff;
-    position: relative;
-    overflow: hidden;
-}
-
-.page-title-bar::after {
-    content: '';
-    position: absolute;
-    inset: 0;
-    background: url("data:image/svg+xml,%3Csvg width='60' height='60' viewBox='0 0 60 60' xmlns='http://www.w3.org/2000/svg'%3E%3Ccircle cx='30' cy='30' r='28' fill='none' stroke='rgba(255,255,255,0.06)' stroke-width='1'/%3E%3C/svg%3E") repeat;
-    pointer-events: none;
-}
-
-.page-title-inner {
-    position: relative;
-    z-index: 1;
-}
-
-.page-title-inner h1 {
-    font-family: var(--neba-font-display);
-    font-size: 2rem;
-    font-weight: 800;
-    letter-spacing: -0.02em;
-}
-
-.page-title-inner p {
-    opacity: 0.8;
-    font-size: 0.95rem;
-    margin-top: 0.35rem;
-    max-width: 620px;
-}
-
 /* ── Panel/card section headings ─────────────────────────── */
 .panel-heading {
     font-family: var(--neba-font-display);
@@ -135,13 +98,3 @@
     padding-top: 0.05rem;
 }
 
-/* ── Responsive ──────────────────────────────────────────── */
-@media (max-width: 640px) {
-    .page-title-inner h1 {
-        font-size: 1.6rem;
-    }
-
-    .page-title-bar {
-        padding: 1.5rem 1.25rem;
-    }
-}

--- a/src/Neba.Website.Server/About/About.razor.css
+++ b/src/Neba.Website.Server/About/About.razor.css
@@ -1,0 +1,147 @@
+/* ── Font utility ─────────────────────────────────────────── */
+.font-display {
+    font-family: var(--neba-font-display);
+}
+
+/* ── Page title bar ──────────────────────────────────────── */
+.page-title-bar {
+    background: linear-gradient(15deg, var(--neba-blue-brand) 0%, #3E4FD9 60%, #5563DD 100%);
+    padding: 2rem 2.5rem;
+    border-radius: var(--radius-xl);
+    color: #fff;
+    position: relative;
+    overflow: hidden;
+}
+
+.page-title-bar::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: url("data:image/svg+xml,%3Csvg width='60' height='60' viewBox='0 0 60 60' xmlns='http://www.w3.org/2000/svg'%3E%3Ccircle cx='30' cy='30' r='28' fill='none' stroke='rgba(255,255,255,0.06)' stroke-width='1'/%3E%3C/svg%3E") repeat;
+    pointer-events: none;
+}
+
+.page-title-inner {
+    position: relative;
+    z-index: 1;
+}
+
+.page-title-inner h1 {
+    font-family: var(--neba-font-display);
+    font-size: 2rem;
+    font-weight: 800;
+    letter-spacing: -0.02em;
+}
+
+.page-title-inner p {
+    opacity: 0.8;
+    font-size: 0.95rem;
+    margin-top: 0.35rem;
+    max-width: 620px;
+}
+
+/* ── Panel/card section headings ─────────────────────────── */
+.panel-heading {
+    font-family: var(--neba-font-display);
+    font-size: 1.05rem;
+    font-weight: 700;
+    color: var(--neba-blue-700);
+    margin-bottom: 0.75rem;
+}
+
+.info-card-heading {
+    font-family: var(--neba-font-display);
+    font-size: 0.78rem;
+    font-weight: 700;
+    color: var(--neba-blue-700);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    margin-bottom: 0.65rem;
+}
+
+/* ── Body text ───────────────────────────────────────────── */
+.section-text {
+    font-size: 0.9rem;
+    color: var(--neba-gray-700);
+    line-height: 1.75;
+}
+
+.section-text + .section-text {
+    margin-top: 0.5rem;
+}
+
+/* ── Squad time badges ───────────────────────────────────── */
+.squad-time-badge {
+    background: var(--neba-gray-100);
+    border: 1px solid var(--neba-gray-200);
+    border-radius: var(--radius-md);
+    padding: 0.3rem 0.75rem;
+    font-size: 0.82rem;
+    font-weight: 500;
+    color: var(--neba-gray-700);
+}
+
+/* ── Fee grid ────────────────────────────────────────────── */
+.fee-grid {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 0.5rem;
+    margin-top: 0.25rem;
+}
+
+.fee-row {
+    display: flex;
+    flex-direction: column;
+    padding: 0.55rem 0.65rem;
+    background: var(--neba-gray-050);
+    border-radius: var(--radius-md);
+    border: 1px solid var(--neba-gray-200);
+}
+
+.fee-label {
+    font-size: 0.78rem;
+    color: var(--neba-gray-600);
+}
+
+.fee-amount {
+    font-family: var(--neba-font-display);
+    font-size: 0.95rem;
+    font-weight: 700;
+    color: var(--neba-blue-700);
+}
+
+/* ── Criteria list ───────────────────────────────────────── */
+.criteria-list {
+    list-style: none;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    margin-top: 0.5rem;
+}
+
+.criteria-list li {
+    display: flex;
+    gap: 0.65rem;
+    font-size: 0.875rem;
+    color: var(--neba-gray-700);
+    line-height: 1.65;
+}
+
+.criteria-list li::before {
+    content: '\2013';
+    color: var(--neba-blue-300);
+    flex-shrink: 0;
+    padding-top: 0.05rem;
+}
+
+/* ── Responsive ──────────────────────────────────────────── */
+@media (max-width: 640px) {
+    .page-title-inner h1 {
+        font-size: 1.6rem;
+    }
+
+    .page-title-bar {
+        padding: 1.5rem 1.25rem;
+    }
+}

--- a/src/Neba.Website.Server/About/Faq.razor
+++ b/src/Neba.Website.Server/About/Faq.razor
@@ -1,0 +1,173 @@
+@page "/about/faq"
+
+<PageTitle>FAQ - NEBA</PageTitle>
+<HeadContent>
+    <meta name="description"
+          content="Answers to the most common questions about bowling in NEBA — membership, tournament format, rules, and more." />
+</HeadContent>
+
+<div class="neba-space-y-6">
+
+    <!-- Page title -->
+    <div class="page-title-bar">
+        <div class="page-title-inner">
+            <h1>Frequently Asked Questions</h1>
+            <p>Answers to the most common questions about bowling in NEBA.</p>
+        </div>
+    </div>
+
+    <!-- Membership & Eligibility -->
+    <div>
+        <div class="faq-category">Membership &amp; Eligibility</div>
+        <div class="faq-list">
+
+            <details class="faq-item">
+                <summary>Who can bowl NEBA?</summary>
+                <div class="faq-body">
+                    <p>Any bowler with a USBC membership in good standing may bowl NEBA, with the following exceptions:</p>
+                    <ul>
+                        <li>Any PBA or PWBA member who has won a PBA, PWBA, or PBA50 national tournament in the past five (5) years (US Open and USBC Masters are exempt)</li>
+                        <li>Any PBA member currently in the top 40 on the national PBA points list for the prior season</li>
+                    </ul>
+                    <p>Any NEBA member in good standing who wins a national title and maintains their NEBA membership can continue to compete in NEBA. <em>Example: Anthony Pepe was a NEBA member before winning his national PBA title, maintains his membership, and therefore continues to compete in NEBA.</em></p>
+                </div>
+            </details>
+
+            <details class="faq-item">
+                <summary>How is NEBA run?</summary>
+                <div class="faq-body">
+                    <p>NEBA is run by and for its members. Day-to-day operations are handled by a board of directors including a President, 1st Vice President, 2nd Vice President, NEBA Manager, Tournament Director, Past Presidents in Good Standing, and Members-at-Large.</p>
+                    <p>Day-of-tournament operations are executed by the NEBA Manager and Tournament Director. By-law decisions are discussed and voted on by the full membership. Quarterly meetings are held to discuss NEBA operations, with a full, open-to-all meeting held in the 4th quarter of each calendar year.</p>
+                </div>
+            </details>
+
+            <details class="faq-item">
+                <summary>I have an idea for improving NEBA. Who should I talk to?</summary>
+                <div class="faq-body">
+                    <p>New ideas are proposed and discussed at board meetings, which are open to all NEBA members. Board meetings are held once per quarter, typically on Zoom, with the annual meeting held at the end of the year.</p>
+                    <p>You can also discuss any idea with anyone on the Executive Committee or Board of Directors.</p>
+                </div>
+            </details>
+
+        </div>
+    </div>
+
+    <!-- Tournament Format & Rules -->
+    <div>
+        <div class="faq-category">Tournament Format &amp; Rules</div>
+        <div class="faq-list">
+
+            <details class="faq-item">
+                <summary>What is the format for a typical NEBA tournament?</summary>
+                <div class="faq-body">
+                    <p>A typical NEBA tournament consists of a five-game qualifying squad followed by bracket-style, one-game elimination finals. There are typically three squads: Saturday at 6 PM, Sunday at 9:00 AM, and Sunday at 12:30 PM. Re-entries are permitted. There is typically no re-oil for the 12:30 PM squad, but there is a re-oil for the finals.</p>
+                    <p>Variations include eliminator finals and special formats for majors — for example, round-robin match play for the Cambridge Credit Invitational, or double-elimination finals for the NEBA Masters.</p>
+                    <p><a href="tournaments/rules" class="rules-link">View full Tournament Rules <svg width="12" height="12" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M9 5l7 7-7 7" /></svg></a></p>
+                </div>
+            </details>
+
+            <details class="faq-item">
+                <summary>What is NEBA's dress code?</summary>
+                <div class="faq-body">
+                    <p>NEBA requires a shirt with a polo-type collar, mock neck collar, or crew neck collar with the bowler's name visible on the back. Only previous NEBA champions are permitted to wear white shirts. Women may wear capris and skirts. Shorts and jeans are allowed if they present a neat appearance, but there are restrictions on gym/athletic wear, leggings, and yoga pants.</p>
+                    <p>The Tournament Director has complete discretion over acceptable dress for NEBA. New bowlers have until their 3rd tournament to obtain a proper jersey/shirt with their name on the back.</p>
+                    <p><a href="tournaments/rules" class="rules-link">Full dress code in Tournament Rules <svg width="12" height="12" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M9 5l7 7-7 7" /></svg></a></p>
+                </div>
+            </details>
+
+            <details class="faq-item">
+                <summary>What balls are legal for use in NEBA?</summary>
+                <div class="faq-body">
+                    <p>Any ball approved by USBC that has reached its worldwide release date can be used in NEBA. The worldwide release date rule ensures that all NEBA bowlers have access to the same equipment. Bowlers using equipment that has not yet reached its worldwide release date will have their scores for that squad disqualified.</p>
+                </div>
+            </details>
+
+            <details class="faq-item">
+                <summary>How are NEBA lane patterns chosen?</summary>
+                <div class="faq-body">
+                    <p>The schedule committee partners with representation from each bowling center in advance of their event to collectively select a pattern. Lane patterns are announced at least 7 days before the tournament.</p>
+                </div>
+            </details>
+
+            <details class="faq-item">
+                <summary>Who can bowl NEBA doubles together?</summary>
+                <div class="faq-body">
+                    <p>For regular doubles tournaments, only one previous champion is permitted per team unless that person has not won a NEBA, PBA, or PWBA title within the last ten (10) years.</p>
+                    <p>For over/under 50 doubles tournaments, only one previous NEBA champion is permitted per team unless the person has not won a NEBA, PBA, or PWBA title within the last five (5) years.</p>
+                    <p><a href="tournaments/rules" class="rules-link">Full doubles rules in Tournament Rules <svg width="12" height="12" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M9 5l7 7-7 7" /></svg></a></p>
+                </div>
+            </details>
+
+            <details class="faq-item">
+                <summary>Who can bowl NEBA trios together?</summary>
+                <div class="faq-body">
+                    <p>Trios teams must consist of a minimum of one (1) non-champion and a maximum of one (1) multi-time champion.</p>
+                    <p><a href="tournaments/rules" class="rules-link">Full trios rules in Tournament Rules <svg width="12" height="12" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M9 5l7 7-7 7" /></svg></a></p>
+                </div>
+            </details>
+
+        </div>
+    </div>
+
+    <!-- Operations & Finances -->
+    <div>
+        <div class="faq-category">Operations &amp; Finances</div>
+        <div class="faq-list">
+
+            <details class="faq-item">
+                <summary>How is sponsorship money used to benefit NEBA members?</summary>
+                <div class="faq-body">
+                    <p>The large majority of sponsorship money each year is distributed directly to prize funds at each event, while the remaining amount is used to offset NEBA operating expenses. At each board meeting, a complete financial analysis of the prior quarter is reviewed.</p>
+                </div>
+            </details>
+
+            <details class="faq-item">
+                <summary>How are NEBA's finances tracked and published?</summary>
+                <div class="faq-body">
+                    <p>NEBA uses QuickBooks to track all of its finances. A full tournament accounting is provided after each NEBA event. More generalized financial statements — such as profit and loss statements and balance sheets — are reviewed at each board meeting and are available to NEBA members upon request.</p>
+                </div>
+            </details>
+
+        </div>
+    </div>
+
+    <!-- Reservations & Logistics -->
+    <div>
+        <div class="faq-category">Reservations &amp; Logistics</div>
+        <div class="faq-list">
+
+            <details class="faq-item">
+                <summary>How do I make a reservation or make changes to a reservation?</summary>
+                <div class="faq-body">
+                    <p>Reservations can be made online from the Tournaments page — select the upcoming event and choose your squad.</p>
+                    <p><a href="tournaments" class="rules-link">View upcoming tournaments <svg width="12" height="12" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M9 5l7 7-7 7" /></svg></a></p>
+                    <p>To change or cancel a reservation, contact the Tournament Director directly:</p>
+                    <ul>
+                        <li><strong>Email:</strong> neba.tdjustin@gmail.com</li>
+                        <li><strong>Phone:</strong> (413) 531-9508</li>
+                    </ul>
+                    <p class="faq-fine-note">Cancellation deadline is Friday at 10:00 PM before the tournament. Failure to cancel may result in a $10 fine.</p>
+                </div>
+            </details>
+
+        </div>
+    </div>
+
+    <!-- Getting Involved -->
+    <div>
+        <div class="faq-category">Getting Involved</div>
+        <div class="faq-list">
+
+            <details class="faq-item">
+                <summary>How can I get more involved with NEBA?</summary>
+                <div class="faq-body">
+                    <p>The best way to engage with NEBA is to attend a quarterly board meeting, which is open to all NEBA members. Look for public announcements on Facebook.</p>
+                    <p>There is also a Board of Directors that takes new applications each year. Additionally, several committees help NEBA run — including the tournament committee, social media, sponsorship, and Hall of Fame — and you can apply to assist with any of them.</p>
+                    <p>There are many non-paid volunteers who contribute to NEBA's success, and new volunteers are always welcome.</p>
+                </div>
+            </details>
+
+        </div>
+    </div>
+
+</div>

--- a/src/Neba.Website.Server/About/Faq.razor.css
+++ b/src/Neba.Website.Server/About/Faq.razor.css
@@ -1,37 +1,5 @@
-/* ── Page title bar ──────────────────────────────────────── */
-.page-title-bar {
-    background: linear-gradient(15deg, var(--neba-blue-brand) 0%, #3E4FD9 60%, #5563DD 100%);
-    padding: 2rem 2.5rem;
-    border-radius: var(--radius-xl);
-    color: #fff;
-    position: relative;
-    overflow: hidden;
-}
-
-.page-title-bar::after {
-    content: '';
-    position: absolute;
-    inset: 0;
-    background: url("data:image/svg+xml,%3Csvg width='60' height='60' viewBox='0 0 60 60' xmlns='http://www.w3.org/2000/svg'%3E%3Ccircle cx='30' cy='30' r='28' fill='none' stroke='rgba(255,255,255,0.06)' stroke-width='1'/%3E%3C/svg%3E") repeat;
-    pointer-events: none;
-}
-
-.page-title-inner {
-    position: relative;
-    z-index: 1;
-}
-
-.page-title-inner h1 {
-    font-family: var(--neba-font-display);
-    font-size: 2rem;
-    font-weight: 800;
-    letter-spacing: -0.02em;
-}
-
+/* ── Page title bar override ─────────────────────────────── */
 .page-title-inner p {
-    opacity: 0.8;
-    font-size: 0.95rem;
-    margin-top: 0.35rem;
     max-width: 560px;
 }
 
@@ -158,14 +126,6 @@
 
 /* ── Responsive ──────────────────────────────────────────── */
 @media (max-width: 640px) {
-    .page-title-inner h1 {
-        font-size: 1.6rem;
-    }
-
-    .page-title-bar {
-        padding: 1.5rem 1.25rem;
-    }
-
     .faq-item summary {
         font-size: 0.875rem;
         padding: 0.85rem 1rem;

--- a/src/Neba.Website.Server/About/Faq.razor.css
+++ b/src/Neba.Website.Server/About/Faq.razor.css
@@ -1,0 +1,177 @@
+/* ── Page title bar ──────────────────────────────────────── */
+.page-title-bar {
+    background: linear-gradient(15deg, var(--neba-blue-brand) 0%, #3E4FD9 60%, #5563DD 100%);
+    padding: 2rem 2.5rem;
+    border-radius: var(--radius-xl);
+    color: #fff;
+    position: relative;
+    overflow: hidden;
+}
+
+.page-title-bar::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: url("data:image/svg+xml,%3Csvg width='60' height='60' viewBox='0 0 60 60' xmlns='http://www.w3.org/2000/svg'%3E%3Ccircle cx='30' cy='30' r='28' fill='none' stroke='rgba(255,255,255,0.06)' stroke-width='1'/%3E%3C/svg%3E") repeat;
+    pointer-events: none;
+}
+
+.page-title-inner {
+    position: relative;
+    z-index: 1;
+}
+
+.page-title-inner h1 {
+    font-family: var(--neba-font-display);
+    font-size: 2rem;
+    font-weight: 800;
+    letter-spacing: -0.02em;
+}
+
+.page-title-inner p {
+    opacity: 0.8;
+    font-size: 0.95rem;
+    margin-top: 0.35rem;
+    max-width: 560px;
+}
+
+/* ── FAQ category heading ────────────────────────────────── */
+.faq-category {
+    font-family: var(--neba-font-display);
+    font-size: 0.78rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.07em;
+    color: var(--neba-gray-500);
+    margin-bottom: 0.65rem;
+    padding-left: 0.15rem;
+}
+
+/* ── FAQ accordion ───────────────────────────────────────── */
+.faq-list {
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+}
+
+.faq-item {
+    border: 1px solid var(--neba-gray-300);
+    border-radius: var(--radius-md);
+    overflow: hidden;
+    background: #fff;
+    box-shadow: var(--shadow-card);
+    transition: border-color 0.15s;
+}
+
+.faq-item[open] {
+    border-color: var(--neba-blue-300);
+}
+
+.faq-item summary {
+    list-style: none;
+    padding: 1rem 1.25rem;
+    cursor: pointer;
+    font-weight: 600;
+    font-size: 0.925rem;
+    color: var(--neba-gray-800);
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 1rem;
+    user-select: none;
+    -webkit-user-select: none;
+}
+
+.faq-item summary::-webkit-details-marker {
+    display: none;
+}
+
+.faq-item summary::after {
+    content: '+';
+    font-size: 1.3rem;
+    color: var(--neba-blue-600);
+    flex-shrink: 0;
+    line-height: 1;
+    font-weight: 400;
+    transition: transform 0.15s;
+}
+
+.faq-item[open] summary {
+    border-bottom: 1px solid var(--neba-blue-100);
+    color: var(--neba-blue-700);
+    background: #f8f9fe;
+}
+
+.faq-item[open] summary::after {
+    content: '\2212';
+}
+
+.faq-body {
+    padding: 1rem 1.25rem;
+    font-size: 0.9rem;
+    color: var(--neba-gray-700);
+    line-height: 1.75;
+    display: flex;
+    flex-direction: column;
+    gap: 0.65rem;
+}
+
+.faq-body ul {
+    list-style: none;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+}
+
+.faq-body ul li {
+    display: flex;
+    gap: 0.6rem;
+}
+
+.faq-body ul li::before {
+    content: '\2013';
+    color: var(--neba-blue-300);
+    flex-shrink: 0;
+}
+
+/* ── Rules link ──────────────────────────────────────────── */
+.rules-link {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.3rem;
+    color: var(--neba-blue-700);
+    font-weight: 600;
+    font-size: 0.875rem;
+    border-bottom: 1px solid var(--neba-blue-200);
+    text-decoration: none;
+}
+
+.rules-link:hover {
+    color: var(--neba-blue-500);
+}
+
+.faq-fine-note {
+    font-size: 0.82rem;
+    color: var(--neba-gray-500);
+}
+
+/* ── Responsive ──────────────────────────────────────────── */
+@media (max-width: 640px) {
+    .page-title-inner h1 {
+        font-size: 1.6rem;
+    }
+
+    .page-title-bar {
+        padding: 1.5rem 1.25rem;
+    }
+
+    .faq-item summary {
+        font-size: 0.875rem;
+        padding: 0.85rem 1rem;
+    }
+
+    .faq-body {
+        padding: 0.85rem 1rem;
+    }
+}

--- a/src/Neba.Website.Server/About/ThingsToKnow.razor
+++ b/src/Neba.Website.Server/About/ThingsToKnow.razor
@@ -1,0 +1,243 @@
+@page "/about/things-to-know"
+
+<PageTitle>Things to Know - NEBA</PageTitle>
+<HeadContent>
+    <meta name="description"
+          content="Everything you need to bowl at a NEBA tournament — arrival, rules, format, and contact info." />
+</HeadContent>
+
+<div class="neba-space-y-6">
+
+    <!-- Page title -->
+    <div class="page-title-bar">
+        <div class="page-title-inner">
+            <h1>Things to Know</h1>
+            <p>Everything you need to bowl at a NEBA tournament — arrival, rules, format, and contact info.</p>
+        </div>
+    </div>
+
+    <!-- Section 1: Arrival -->
+    <div class="ttk-panel">
+        <div class="section-header">
+            <div class="section-number">1</div>
+            <h2>Arrival</h2>
+        </div>
+        <div class="rule-list">
+
+            <div class="rule-item">
+                <div class="rule-label">Check-In</div>
+                <div>
+                    <p class="section-text">Check in <strong>30 minutes prior to squad time</strong>. Reservations not acknowledged by this time are no longer guaranteed.</p>
+                    <p class="section-text">Failure to keep your reservation may result in a <span class="fine-badge">$10 fine</span>.</p>
+                    <p class="section-text">To cancel, contact the Tournament Director:</p>
+                    <p class="section-text">
+                        <strong>Justin</strong> — <a href="tel:4135319508" class="contact-link">(413) 531-9508</a> or <a href="mailto:neba.tdjustin@gmail.com" class="contact-link">neba.tdjustin@gmail.com</a><br />
+                        <strong>Danny</strong> — <a href="tel:2036274800" class="contact-link">(203) 627-4800</a> or <a href="mailto:info@bowlneba.com" class="contact-link">info@bowlneba.com</a>
+                    </p>
+                </div>
+            </div>
+
+            <div class="rule-item">
+                <div class="rule-label">Membership</div>
+                <div>
+                    <p class="section-text">Renewable by calendar year at <strong>$25</strong>. Members joining after November 1 remain in good standing for the following year. Non-members may bowl for a <strong>$15 per tournament</strong> fee.</p>
+                    <p class="section-text"><strong>Membership is open to bowlers who meet all of the following:</strong></p>
+                    <ul class="criteria-list">
+                        <li>Possesses a current USBC membership card (obtained when applying by paying the current annual USBC fee)</li>
+                        <li>Has attained age 18, or has graduated from high school, or has written parent/guardian approval per current USBC rules</li>
+                        <li>Any PBA or PWBA member who has not won a PBA, PWBA, or PBA50 national tournament in the past five (5) years (US Open and USBC Masters are exempt) and is not in the top 40 on the national PBA points list for the prior season</li>
+                        <li>Any NEBA member in good standing who wins a national title and maintains their NEBA membership may continue to compete in NEBA</li>
+                    </ul>
+                </div>
+            </div>
+
+            <div class="rule-item">
+                <div class="rule-label">Entry Fees</div>
+                <div>
+                    <div class="fee-grid">
+                        <div class="fee-row"><span class="fee-label">Regular tournaments</span><span class="fee-amount">$100</span></div>
+                        <div class="fee-row"><span class="fee-label">Tournament of Champions</span><span class="fee-amount">$125</span></div>
+                        <div class="fee-row"><span class="fee-label">Cambridge Credit Invit.</span><span class="fee-amount">$100</span></div>
+                        <div class="fee-row"><span class="fee-label">Masters</span><span class="fee-amount">$150</span></div>
+                    </div>
+                    <p class="section-text fee-note">Fee applies to first entry and re-entries.</p>
+                </div>
+            </div>
+
+            <div class="rule-item">
+                <div class="rule-label">Side Pots</div>
+                <div>
+                    <div class="side-pot-grid">
+                        <div class="side-pot-badge">
+                            <span class="pot-amount">$20</span>
+                            <span class="pot-label">High game (each game)</span>
+                        </div>
+                        <div class="side-pot-badge">
+                            <span class="pot-amount">$5</span>
+                            <span class="pot-label">Squad leader</span>
+                        </div>
+                        <div class="side-pot-badge">
+                            <span class="pot-amount">$5</span>
+                            <span class="pot-label">Brackets (games 2–3–4)</span>
+                        </div>
+                        <div class="side-pot-badge">
+                            <span class="pot-amount">$10</span>
+                            <span class="pot-label">Eliminator</span>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+        </div>
+    </div>
+
+    <!-- Section 2: Rules & Etiquette -->
+    <div class="ttk-panel">
+        <div class="section-header">
+            <div class="section-number">2</div>
+            <h2>Rules &amp; Etiquette</h2>
+        </div>
+        <div class="rule-list">
+
+            <div class="rule-item">
+                <div class="rule-label">Eligibility</div>
+                <div>
+                    <p class="section-text">Any USBC-sanctioned adult bowler may participate. PBA-exempt tour players are not allowed to bowl. USBC Youth members may bowl in singles tournaments only and must sign waivers stating that any prize money won will be deposited into their USBC SMART account.</p>
+                </div>
+            </div>
+
+            <div class="rule-item">
+                <div class="rule-label">35-Mile Rule</div>
+                <div>
+                    <p class="section-text">Bowlers within 35 miles of the host center must bowl their first squad on <strong>Saturday night (6 PM)</strong> or <strong>Sunday morning (9 AM)</strong>. Bowlers within a 35-mile radius hold last priority for the 12:30 PM squad.</p>
+                </div>
+            </div>
+
+            <div class="rule-item">
+                <div class="rule-label">Dress Code</div>
+                <div>
+                    <div class="dress-cols">
+                        <div class="dress-block dress-allowed">
+                            <h4>Allowed</h4>
+                            <ul class="dress-list">
+                                <li>Collared or mock neck (bowling industry) shirts</li>
+                                <li>Pants, jeans, or dress shorts (no nylon or basketball-type)</li>
+                                <li>Women may wear capris and skirts</li>
+                                <li>Bowler's name on back (required within first 3 tournaments)</li>
+                                <li>White shirts — NEBA Champions only</li>
+                            </ul>
+                        </div>
+                        <div class="dress-block dress-not-allowed">
+                            <h4>Not Allowed</h4>
+                            <ul class="dress-list">
+                                <li>Sweatpants, gym/athletic shorts, yoga pants, leggings, or tights</li>
+                                <li>Ripped, frayed, or torn clothing</li>
+                                <li>Hats, headbands, headphones, or earbuds</li>
+                                <li>White shirts (unless a previous NEBA champion)</li>
+                            </ul>
+                        </div>
+                    </div>
+                    <div class="callout-note">
+                        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="10" /><line x1="12" y1="8" x2="12" y2="12" /><line x1="12" y1="16" x2="12.01" y2="16" /></svg>
+                        Missing name on shirt: <span class="fine-badge">$10 fine</span> per tournament. Repeated offenses: <span class="fine-badge">$25 fine</span>. New bowlers have until their 3rd tournament to obtain a proper jersey. The Tournament Director has complete discretion over acceptable dress.
+                    </div>
+                </div>
+            </div>
+
+            <div class="rule-item">
+                <div class="rule-label">Lane Courtesy</div>
+                <div>
+                    <p class="section-text"><strong>Two-lane courtesy</strong> during qualifying and match play.</p>
+                </div>
+            </div>
+
+            <div class="rule-item">
+                <div class="rule-label">Conduct</div>
+                <div>
+                    <p class="section-text">Loud, unruly, and disrespectful behavior will not be allowed. Excessive celebration is also unacceptable.</p>
+                </div>
+            </div>
+
+        </div>
+    </div>
+
+    <!-- Section 3: Tournament Format -->
+    <div class="ttk-panel">
+        <div class="section-header">
+            <div class="section-number">3</div>
+            <h2>Tournament Format</h2>
+        </div>
+
+        <div class="rule-item rule-item-bordered">
+            <div class="rule-label">Qualifying</div>
+            <div>
+                <div class="format-row">
+                    <div class="format-step">
+                        <div class="step-num">5</div>
+                        <div class="step-lbl">Games</div>
+                    </div>
+                    <div class="format-arrow">&#8594;</div>
+                    <div class="format-step">
+                        <div class="step-num">10</div>
+                        <div class="step-lbl">Lanes</div>
+                    </div>
+                    <div class="format-arrow">&#8594;</div>
+                    <div class="format-step">
+                        <div class="step-num">3</div>
+                        <div class="step-lbl">Squads</div>
+                    </div>
+                </div>
+                <p class="section-text format-note">Lane cross determined by total number of lanes used per squad. Re-entries are permitted. Squads: <strong>Saturday 6 PM, Sunday 9 AM, Sunday 12:30 PM.</strong></p>
+            </div>
+        </div>
+
+        <div class="cut-list">
+            <div class="cut-item">
+                <div class="cut-label">Squad Cut</div>
+                <div class="cut-desc">One in six of each squad is guaranteed to make match play finals (e.g., 48 bowlers &rarr; top 8 guaranteed). Each squad leader is guaranteed a top-3 seed in the final bracket.</div>
+            </div>
+            <div class="cut-item">
+                <div class="cut-label">At-Large Cut</div>
+                <div class="cut-desc">All other bowlers who did not qualify via squad cut enter the at-large pool. Total qualifiers are based on total entries for the tournament.</div>
+            </div>
+            <div class="cut-item">
+                <div class="cut-label">Seniors / Women / Super Seniors</div>
+                <div class="cut-desc">One in seven seniors (50+), Super Seniors (60+), and women are each guaranteed to make the finals in 3 separate cuts (e.g., 20 seniors &rarr; 3 guaranteed). Bowlers qualifying via squad or at-large cuts count toward these guarantees.</div>
+            </div>
+            <div class="cut-item cut-item-last">
+                <div class="cut-label">Match Play</div>
+                <div class="cut-desc">Lanes are re-oiled before match play (except in single-squad tournaments). Roll call at approximately <strong>3:30 PM Sunday</strong>. Single-game elimination matches. Top-seeded bowlers may receive first-round byes based on total qualifiers.</div>
+            </div>
+        </div>
+    </div>
+
+    <!-- Section 4: Contact -->
+    <div class="ttk-panel">
+        <div class="section-header">
+            <div class="section-number">4</div>
+            <h2>Contact Information</h2>
+        </div>
+        <div class="contact-grid">
+            <div class="contact-card">
+                <div class="contact-role">Tournament Director</div>
+                <div class="contact-name">Justin</div>
+                <div class="contact-phone">(413) 531-9508</div>
+                <div class="contact-email">neba.tdjustin@gmail.com</div>
+            </div>
+            <div class="contact-card">
+                <div class="contact-role">NEBA Manager</div>
+                <div class="contact-name">Dan</div>
+                <div class="contact-phone">(203) 627-4800</div>
+                <div class="contact-email">info@bowlneba.com</div>
+            </div>
+            <div class="contact-card contact-card-full">
+                <div class="contact-role">Website &amp; General</div>
+                <div class="contact-web">
+                    <a href="https://www.BowlNEBA.com" class="contact-web-link">www.BowlNEBA.com</a>
+                    <a href="mailto:info@bowlneba.com" class="contact-email-link">info@BowlNEBA.com</a>
+                </div>
+            </div>
+        </div>
+    </div>
+
+</div>

--- a/src/Neba.Website.Server/About/ThingsToKnow.razor.css
+++ b/src/Neba.Website.Server/About/ThingsToKnow.razor.css
@@ -1,0 +1,509 @@
+/* ── Page title bar ──────────────────────────────────────── */
+.page-title-bar {
+    background: linear-gradient(15deg, var(--neba-blue-brand) 0%, #3E4FD9 60%, #5563DD 100%);
+    padding: 2rem 2.5rem;
+    border-radius: var(--radius-xl);
+    color: #fff;
+    position: relative;
+    overflow: hidden;
+}
+
+.page-title-bar::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: url("data:image/svg+xml,%3Csvg width='60' height='60' viewBox='0 0 60 60' xmlns='http://www.w3.org/2000/svg'%3E%3Ccircle cx='30' cy='30' r='28' fill='none' stroke='rgba(255,255,255,0.06)' stroke-width='1'/%3E%3C/svg%3E") repeat;
+    pointer-events: none;
+}
+
+.page-title-inner {
+    position: relative;
+    z-index: 1;
+}
+
+.page-title-inner h1 {
+    font-family: var(--neba-font-display);
+    font-size: 2rem;
+    font-weight: 800;
+    letter-spacing: -0.02em;
+}
+
+.page-title-inner p {
+    opacity: 0.8;
+    font-size: 0.95rem;
+    margin-top: 0.35rem;
+    max-width: 620px;
+}
+
+/* ── Shared panel ────────────────────────────────────────── */
+.ttk-panel {
+    background: #fff;
+    border: 1px solid var(--neba-gray-300);
+    border-radius: var(--radius-md);
+    padding: 1.5rem 1.75rem;
+}
+
+/* ── Section header ──────────────────────────────────────── */
+.section-header {
+    display: flex;
+    align-items: center;
+    gap: 0.65rem;
+    margin-bottom: 1.25rem;
+}
+
+.section-number {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 1.6rem;
+    height: 1.6rem;
+    background: var(--neba-blue-100);
+    color: var(--neba-blue-700);
+    border-radius: 50%;
+    font-family: var(--neba-font-display);
+    font-size: 0.78rem;
+    font-weight: 800;
+    flex-shrink: 0;
+}
+
+.section-header h2 {
+    font-family: var(--neba-font-display);
+    font-size: 1.1rem;
+    font-weight: 700;
+    color: var(--neba-blue-brand);
+}
+
+/* ── Rule rows ───────────────────────────────────────────── */
+.rule-list {
+    display: flex;
+    flex-direction: column;
+    gap: 0;
+}
+
+.rule-item {
+    padding: 1rem 0;
+    border-bottom: 1px solid var(--neba-gray-200);
+    display: grid;
+    grid-template-columns: 160px 1fr;
+    gap: 1rem;
+    align-items: start;
+}
+
+.rule-item:last-child {
+    border-bottom: none;
+    padding-bottom: 0;
+}
+
+.rule-item:first-child {
+    padding-top: 0;
+}
+
+.rule-item-bordered {
+    border-bottom: 1px solid var(--neba-gray-200);
+    padding-bottom: 1rem;
+    margin-bottom: 0;
+    padding-top: 0;
+}
+
+.rule-label {
+    font-weight: 700;
+    font-size: 0.82rem;
+    color: var(--neba-blue-700);
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    padding-top: 0.1rem;
+    flex-shrink: 0;
+}
+
+.section-text {
+    font-size: 0.9rem;
+    color: var(--neba-gray-700);
+    line-height: 1.75;
+}
+
+.section-text + .section-text {
+    margin-top: 0.5rem;
+}
+
+/* ── Criteria list ───────────────────────────────────────── */
+.criteria-list {
+    list-style: none;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    margin-top: 0.5rem;
+}
+
+.criteria-list li {
+    display: flex;
+    gap: 0.65rem;
+    font-size: 0.875rem;
+    color: var(--neba-gray-700);
+    line-height: 1.65;
+}
+
+.criteria-list li::before {
+    content: '\2013';
+    color: var(--neba-blue-300);
+    flex-shrink: 0;
+    padding-top: 0.05rem;
+}
+
+/* ── Fee grid ────────────────────────────────────────────── */
+.fee-grid {
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    gap: 0.5rem;
+    margin-top: 0.5rem;
+}
+
+.fee-row {
+    display: flex;
+    flex-direction: column;
+    padding: 0.55rem 0.65rem;
+    background: var(--neba-gray-050);
+    border-radius: var(--radius-md);
+    border: 1px solid var(--neba-gray-200);
+}
+
+.fee-label {
+    font-size: 0.78rem;
+    color: var(--neba-gray-600);
+}
+
+.fee-amount {
+    font-family: var(--neba-font-display);
+    font-size: 0.95rem;
+    font-weight: 700;
+    color: var(--neba-blue-700);
+}
+
+.fee-note {
+    margin-top: 0.6rem;
+    font-size: 0.82rem;
+    color: var(--neba-gray-500);
+}
+
+/* ── Side pot badges ─────────────────────────────────────── */
+.side-pot-grid {
+    display: flex;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+    margin-top: 0.5rem;
+}
+
+.side-pot-badge {
+    background: var(--neba-gray-100);
+    border: 1px solid var(--neba-gray-200);
+    border-radius: var(--radius-md);
+    padding: 0.3rem 0.75rem;
+    font-size: 0.82rem;
+    font-weight: 600;
+    color: var(--neba-gray-700);
+    display: flex;
+    flex-direction: column;
+    gap: 0.05rem;
+}
+
+.pot-amount {
+    font-family: var(--neba-font-display);
+    font-size: 1rem;
+    font-weight: 800;
+    color: var(--neba-blue-700);
+}
+
+.pot-label {
+    font-size: 0.72rem;
+    color: var(--neba-gray-500);
+    font-weight: 500;
+}
+
+/* ── Dress code ──────────────────────────────────────────── */
+.dress-cols {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 1.25rem;
+    margin-top: 0.5rem;
+}
+
+.dress-block h4 {
+    font-size: 0.8rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    margin-bottom: 0.5rem;
+}
+
+.dress-allowed h4 {
+    color: #16a34a;
+}
+
+.dress-not-allowed h4 {
+    color: #dc2626;
+}
+
+.dress-list {
+    list-style: none;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.3rem;
+}
+
+.dress-list li {
+    display: flex;
+    gap: 0.5rem;
+    font-size: 0.85rem;
+    color: var(--neba-gray-700);
+    line-height: 1.5;
+}
+
+.dress-allowed .dress-list li::before {
+    content: '\2713';
+    color: #16a34a;
+    font-weight: 700;
+    flex-shrink: 0;
+}
+
+.dress-not-allowed .dress-list li::before {
+    content: '\2717';
+    color: #dc2626;
+    font-weight: 700;
+    flex-shrink: 0;
+}
+
+/* ── Callout note ────────────────────────────────────────── */
+.callout-note {
+    background: var(--neba-blue-100);
+    border: 1px solid var(--neba-blue-200);
+    border-radius: var(--radius-md);
+    padding: 0.65rem 0.9rem;
+    font-size: 0.82rem;
+    color: var(--neba-blue-brand);
+    line-height: 1.6;
+    display: flex;
+    gap: 0.5rem;
+    align-items: flex-start;
+    margin-top: 0.75rem;
+}
+
+.callout-note svg {
+    flex-shrink: 0;
+    margin-top: 0.1rem;
+}
+
+/* ── Fine badge ──────────────────────────────────────────── */
+.fine-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.3rem;
+    background: #fef3c7;
+    border: 1px solid #fcd34d;
+    border-radius: var(--radius-md);
+    padding: 0.15rem 0.5rem;
+    font-size: 0.75rem;
+    font-weight: 600;
+    color: #92400e;
+}
+
+/* ── Contact link ────────────────────────────────────────── */
+.contact-link {
+    color: var(--neba-blue-700);
+    font-weight: 600;
+    text-decoration: none;
+}
+
+.contact-link:hover {
+    color: var(--neba-blue-500);
+}
+
+/* ── Format visual ───────────────────────────────────────── */
+.format-row {
+    display: flex;
+    align-items: center;
+    gap: 1.5rem;
+    margin-top: 0.5rem;
+    flex-wrap: wrap;
+}
+
+.format-step {
+    text-align: center;
+}
+
+.step-num {
+    font-family: var(--neba-font-display);
+    font-size: 1.5rem;
+    font-weight: 800;
+    color: var(--neba-blue-700);
+}
+
+.step-lbl {
+    font-size: 0.75rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--neba-gray-500);
+    margin-top: 0.1rem;
+}
+
+.format-arrow {
+    color: var(--neba-gray-400);
+    font-size: 1.25rem;
+}
+
+.format-note {
+    margin-top: 0.75rem;
+}
+
+/* ── Cut list ────────────────────────────────────────────── */
+.cut-list {
+    display: flex;
+    flex-direction: column;
+    gap: 0;
+    margin-top: 0.75rem;
+}
+
+.cut-item {
+    padding: 0.7rem 0;
+    border-bottom: 1px solid var(--neba-gray-200);
+    display: grid;
+    grid-template-columns: 180px 1fr;
+    gap: 1rem;
+    align-items: start;
+}
+
+.cut-item-last {
+    border-bottom: none;
+    padding-bottom: 0;
+}
+
+.cut-label {
+    font-weight: 700;
+    font-size: 0.82rem;
+    color: var(--neba-blue-brand);
+}
+
+.cut-desc {
+    font-size: 0.875rem;
+    color: var(--neba-gray-700);
+    line-height: 1.65;
+}
+
+/* ── Contact grid ────────────────────────────────────────── */
+.contact-grid {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 1rem;
+    margin-top: 0.5rem;
+}
+
+.contact-card {
+    background: var(--neba-gray-050);
+    border: 1px solid var(--neba-gray-200);
+    border-radius: var(--radius-md);
+    padding: 1rem 1.25rem;
+}
+
+.contact-card-full {
+    grid-column: span 2;
+}
+
+.contact-role {
+    font-size: 0.78rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--neba-gray-500);
+    margin-bottom: 0.25rem;
+}
+
+.contact-name {
+    font-family: var(--neba-font-display);
+    font-size: 0.95rem;
+    font-weight: 700;
+    color: var(--neba-gray-800);
+    margin-bottom: 0.35rem;
+}
+
+.contact-phone {
+    font-family: var(--neba-font-display);
+    font-size: 1.1rem;
+    font-weight: 800;
+    color: var(--neba-blue-700);
+}
+
+.contact-email {
+    font-size: 0.82rem;
+    color: var(--neba-blue-600);
+    margin-top: 0.15rem;
+    word-break: break-all;
+}
+
+.contact-web {
+    display: flex;
+    align-items: center;
+    gap: 1.5rem;
+    margin-top: 0.25rem;
+    flex-wrap: wrap;
+}
+
+.contact-web-link {
+    color: var(--neba-blue-700);
+    font-weight: 700;
+    font-size: 1rem;
+    text-decoration: none;
+}
+
+.contact-email-link {
+    color: var(--neba-blue-600);
+    font-size: 0.9rem;
+    text-decoration: none;
+}
+
+/* ── Responsive ──────────────────────────────────────────── */
+@media (max-width: 900px) {
+    .fee-grid {
+        grid-template-columns: repeat(2, 1fr);
+    }
+
+    .contact-grid {
+        grid-template-columns: 1fr;
+    }
+
+    .contact-card-full {
+        grid-column: span 1;
+    }
+
+    .rule-item,
+    .cut-item {
+        grid-template-columns: 1fr;
+        gap: 0.25rem;
+    }
+
+    .rule-label {
+        padding-bottom: 0.1rem;
+    }
+}
+
+@media (max-width: 640px) {
+    .page-title-inner h1 {
+        font-size: 1.6rem;
+    }
+
+    .page-title-bar {
+        padding: 1.5rem 1.25rem;
+    }
+
+    .dress-cols {
+        grid-template-columns: 1fr;
+    }
+
+    .fee-grid {
+        grid-template-columns: 1fr 1fr;
+    }
+
+    .ttk-panel {
+        padding: 1.25rem 1rem;
+    }
+}

--- a/src/Neba.Website.Server/About/ThingsToKnow.razor.css
+++ b/src/Neba.Website.Server/About/ThingsToKnow.razor.css
@@ -1,40 +1,3 @@
-/* ── Page title bar ──────────────────────────────────────── */
-.page-title-bar {
-    background: linear-gradient(15deg, var(--neba-blue-brand) 0%, #3E4FD9 60%, #5563DD 100%);
-    padding: 2rem 2.5rem;
-    border-radius: var(--radius-xl);
-    color: #fff;
-    position: relative;
-    overflow: hidden;
-}
-
-.page-title-bar::after {
-    content: '';
-    position: absolute;
-    inset: 0;
-    background: url("data:image/svg+xml,%3Csvg width='60' height='60' viewBox='0 0 60 60' xmlns='http://www.w3.org/2000/svg'%3E%3Ccircle cx='30' cy='30' r='28' fill='none' stroke='rgba(255,255,255,0.06)' stroke-width='1'/%3E%3C/svg%3E") repeat;
-    pointer-events: none;
-}
-
-.page-title-inner {
-    position: relative;
-    z-index: 1;
-}
-
-.page-title-inner h1 {
-    font-family: var(--neba-font-display);
-    font-size: 2rem;
-    font-weight: 800;
-    letter-spacing: -0.02em;
-}
-
-.page-title-inner p {
-    opacity: 0.8;
-    font-size: 0.95rem;
-    margin-top: 0.35rem;
-    max-width: 620px;
-}
-
 /* ── Shared panel ────────────────────────────────────────── */
 .ttk-panel {
     background: #fff;
@@ -487,14 +450,6 @@
 }
 
 @media (max-width: 640px) {
-    .page-title-inner h1 {
-        font-size: 1.6rem;
-    }
-
-    .page-title-bar {
-        padding: 1.5rem 1.25rem;
-    }
-
     .dress-cols {
         grid-template-columns: 1fr;
     }

--- a/src/Neba.Website.Server/Layout/NavMenu.razor
+++ b/src/Neba.Website.Server/Layout/NavMenu.razor
@@ -45,6 +45,8 @@
                             <a href="#" class="neba-nav-link" aria-haspopup="true" aria-expanded="false"
                                @onclick:preventDefault>About</a>
                             <div class="neba-dropdown" role="menu">
+                                <NavLink class="neba-dropdown-link" href="about" Match="NavLinkMatch.All" role="menuitem">About NEBA</NavLink>
+                                <div class="neba-dropdown-divider"></div>
                                 <NavLink class="neba-dropdown-link" href="bylaws" role="menuitem">Bylaws</NavLink>
                                 <div class="neba-dropdown-divider"></div>
                                 <NavLink class="neba-dropdown-link" href="about/faq" role="menuitem">FAQ</NavLink>

--- a/src/Neba.Website.Server/Layout/NavMenu.razor
+++ b/src/Neba.Website.Server/Layout/NavMenu.razor
@@ -46,6 +46,9 @@
                                @onclick:preventDefault>About</a>
                             <div class="neba-dropdown" role="menu">
                                 <NavLink class="neba-dropdown-link" href="bylaws" role="menuitem">Bylaws</NavLink>
+                                <div class="neba-dropdown-divider"></div>
+                                <NavLink class="neba-dropdown-link" href="about/faq" role="menuitem">FAQ</NavLink>
+                                <NavLink class="neba-dropdown-link" href="about/things-to-know" role="menuitem">Things to Know</NavLink>
                             </div>
                         </li>
                         <li class="neba-nav-item">

--- a/src/Neba.Website.Server/wwwroot/app.css
+++ b/src/Neba.Website.Server/wwwroot/app.css
@@ -158,3 +158,50 @@ h1:focus {
 #blazor-reconnect-modal.components-reconnect-rejected {
     display: block;
 }
+
+/* ── Page title bar (shared across About, FAQ, ThingsToKnow) ─────────── */
+.page-title-bar {
+    background: linear-gradient(15deg, var(--neba-blue-brand) 0%, #3E4FD9 60%, #5563DD 100%);
+    padding: 2rem 2.5rem;
+    border-radius: var(--radius-xl);
+    color: #fff;
+    position: relative;
+    overflow: hidden;
+}
+
+.page-title-bar::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: url("data:image/svg+xml,%3Csvg width='60' height='60' viewBox='0 0 60 60' xmlns='http://www.w3.org/2000/svg'%3E%3Ccircle cx='30' cy='30' r='28' fill='none' stroke='rgba(255,255,255,0.06)' stroke-width='1'/%3E%3C/svg%3E") repeat;
+    pointer-events: none;
+}
+
+.page-title-inner {
+    position: relative;
+    z-index: 1;
+}
+
+.page-title-inner h1 {
+    font-family: var(--neba-font-display);
+    font-size: 2rem;
+    font-weight: 800;
+    letter-spacing: -0.02em;
+}
+
+.page-title-inner p {
+    opacity: 0.8;
+    font-size: 0.95rem;
+    margin-top: 0.35rem;
+    max-width: 620px;
+}
+
+@media (max-width: 640px) {
+    .page-title-inner h1 {
+        font-size: 1.6rem;
+    }
+
+    .page-title-bar {
+        padding: 1.5rem 1.25rem;
+    }
+}

--- a/tests/Neba.Website.Tests/About/AboutPageTests.cs
+++ b/tests/Neba.Website.Tests/About/AboutPageTests.cs
@@ -1,0 +1,224 @@
+using Bunit;
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+
+using Neba.Api.Contracts;
+using Neba.Api.Contracts.Sponsors;
+using Neba.Api.Features.Sponsors.Domain;
+using Neba.TestFactory.Attributes;
+using Neba.TestFactory.Sponsors;
+using Neba.Website.Server.Clock;
+using Neba.Website.Server.Services;
+
+using Refit;
+
+using AboutPage = Neba.Website.Server.About.About;
+
+namespace Neba.Website.Tests.About;
+
+[UnitTest]
+[Component("Website.About.About")]
+public sealed class AboutPageTests : IDisposable
+{
+    private readonly BunitContext _ctx;
+    private readonly Mock<ISponsorsApi> _mockApi;
+
+    public AboutPageTests()
+    {
+        _mockApi = new Mock<ISponsorsApi>(MockBehavior.Strict);
+
+        var mockStopwatch = new Mock<IStopwatchProvider>(MockBehavior.Strict);
+        mockStopwatch.Setup(x => x.GetTimestamp()).Returns(0L);
+        mockStopwatch.Setup(x => x.GetElapsedTime(It.IsAny<long>())).Returns(TimeSpan.Zero);
+
+        _ctx = new BunitContext();
+        _ctx.JSInterop.Mode = JSRuntimeMode.Loose;
+
+        _ctx.Services.AddSingleton(_mockApi.Object);
+        _ctx.Services.AddSingleton(new ApiExecutor(mockStopwatch.Object, NullLogger<ApiExecutor>.Instance));
+    }
+
+    public void Dispose() => _ctx.Dispose();
+
+    // ── Loading state ────────────────────────────────────────────────────────
+
+    [Fact(DisplayName = "Should show loading skeleton while API is pending")]
+    public void Render_ShouldShowLoadingSkeleton_WhileLoading()
+    {
+        // Arrange
+        _mockApi
+            .Setup(x => x.ListActiveSponsorsAsync(It.IsAny<CancellationToken>()))
+            .Returns(new TaskCompletionSource<IApiResponse<CollectionResponse<SponsorSummaryResponse>>>().Task);
+
+        // Act
+        var cut = _ctx.Render<AboutPage>();
+
+        // Assert
+        cut.Markup.ShouldContain("aria-busy=\"true\"");
+    }
+
+    // ── Error state ──────────────────────────────────────────────────────────
+
+    [Fact(DisplayName = "Should show error alert when API call fails")]
+    public void Render_ShouldShowErrorAlert_WhenApiFails()
+    {
+        // Arrange
+        SetupFailureResponse(System.Net.HttpStatusCode.InternalServerError);
+
+        // Act
+        var cut = _ctx.Render<AboutPage>();
+
+        // Assert
+        cut.Markup.ShouldContain("Error Loading Sponsors");
+    }
+
+    // ── Title sponsor ────────────────────────────────────────────────────────
+
+    [Fact(DisplayName = "Should show title sponsor name when title sponsor exists")]
+    public void Render_ShouldShowTitleSponsorName_WhenTitleSponsorExists()
+    {
+        // Arrange
+        var sponsor = SponsorSummaryResponseFactory.Create(name: "Acme Corp", tier: SponsorTier.TitleSponsor);
+        SetupSuccessResponse([sponsor]);
+
+        // Act
+        var cut = _ctx.Render<AboutPage>();
+
+        // Assert
+        cut.Markup.ShouldContain("Title Sponsor");
+        cut.Markup.ShouldContain("Acme Corp");
+    }
+
+    [Fact(DisplayName = "Should not show title sponsor section when no title sponsor exists")]
+    public void Render_ShouldNotShowTitleSponsorSection_WhenNoTitleSponsor()
+    {
+        // Arrange
+        SetupSuccessResponse([]);
+
+        // Act
+        var cut = _ctx.Render<AboutPage>();
+
+        // Assert
+        cut.Markup.ShouldNotContain("Title Sponsor");
+    }
+
+    [Fact(DisplayName = "Should link to title sponsor detail page")]
+    public void Render_ShouldLinkToTitleSponsorDetailPage_WhenTitleSponsorExists()
+    {
+        // Arrange
+        var sponsor = SponsorSummaryResponseFactory.Create(slug: "acme-corp", tier: SponsorTier.TitleSponsor);
+        SetupSuccessResponse([sponsor]);
+
+        // Act
+        var cut = _ctx.Render<AboutPage>();
+
+        // Assert
+        cut.Markup.ShouldContain("/sponsors/acme-corp");
+    }
+
+    // ── Premier sponsors ─────────────────────────────────────────────────────
+
+    [Fact(DisplayName = "Should show Premier Partners section when premier sponsors exist")]
+    public void Render_ShouldShowPremierPartnersSection_WhenPremierSponsorsExist()
+    {
+        // Arrange
+        var sponsor = SponsorSummaryResponseFactory.Create(name: "Premier Co", tier: SponsorTier.Premier);
+        SetupSuccessResponse([sponsor]);
+
+        // Act
+        var cut = _ctx.Render<AboutPage>();
+
+        // Assert
+        cut.Markup.ShouldContain("Premier Partners");
+        cut.Markup.ShouldContain("Premier Co");
+    }
+
+    [Fact(DisplayName = "Should not show Premier Partners section when no premier sponsors exist")]
+    public void Render_ShouldNotShowPremierPartnersSection_WhenNoPremierSponsors()
+    {
+        // Arrange
+        SetupSuccessResponse([]);
+
+        // Act
+        var cut = _ctx.Render<AboutPage>();
+
+        // Assert
+        cut.Markup.ShouldNotContain("Premier Partners");
+    }
+
+    [Fact(DisplayName = "Should not show standard-tier sponsors in the sponsors section")]
+    public void Render_ShouldNotShowStandardSponsor_WhenOnlyStandardSponsorExists()
+    {
+        // Arrange
+        var sponsor = SponsorSummaryResponseFactory.Create(name: "Standard Corp", tier: SponsorTier.Standard);
+        SetupSuccessResponse([sponsor]);
+
+        // Act
+        var cut = _ctx.Render<AboutPage>();
+
+        // Assert
+        cut.Markup.ShouldContain("Sponsor information is not currently available.");
+        cut.Markup.ShouldNotContain("Standard Corp");
+    }
+
+    [Fact(DisplayName = "Should render premier sponsors ordered by priority then name")]
+    public void Render_ShouldOrderPremierSponsorsByPriorityThenName()
+    {
+        // Arrange
+        SetupSuccessResponse([
+            SponsorSummaryResponseFactory.Create(name: "Zebra Co", priority: 1, tier: SponsorTier.Premier),
+            SponsorSummaryResponseFactory.Create(name: "Alpha Co", priority: 2, tier: SponsorTier.Premier),
+            SponsorSummaryResponseFactory.Create(name: "Middle Co", priority: 1, tier: SponsorTier.Premier),
+        ]);
+
+        // Act
+        var cut = _ctx.Render<AboutPage>();
+        var markup = cut.Markup;
+
+        // Assert
+        markup.IndexOf("Zebra Co", StringComparison.Ordinal)
+            .ShouldBeLessThan(markup.IndexOf("Alpha Co", StringComparison.Ordinal));
+        markup.IndexOf("Middle Co", StringComparison.Ordinal)
+            .ShouldBeLessThan(markup.IndexOf("Zebra Co", StringComparison.Ordinal));
+    }
+
+    [Fact(DisplayName = "Should show empty state message when no title or premier sponsors exist")]
+    public void Render_ShouldShowEmptyState_WhenNoTitleOrPremierSponsors()
+    {
+        // Arrange
+        SetupSuccessResponse([]);
+
+        // Act
+        var cut = _ctx.Render<AboutPage>();
+
+        // Assert
+        cut.Markup.ShouldContain("Sponsor information is not currently available.");
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────────
+
+    private void SetupSuccessResponse(IReadOnlyCollection<SponsorSummaryResponse> sponsors)
+    {
+        var response = new Mock<IApiResponse<CollectionResponse<SponsorSummaryResponse>>>(MockBehavior.Strict);
+        response.Setup(r => r.IsSuccessStatusCode).Returns(true);
+        response.Setup(r => r.StatusCode).Returns(System.Net.HttpStatusCode.OK);
+        response.Setup(r => r.Content).Returns(new CollectionResponse<SponsorSummaryResponse> { Items = sponsors });
+
+        _mockApi
+            .Setup(x => x.ListActiveSponsorsAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(response.Object);
+    }
+
+    private void SetupFailureResponse(System.Net.HttpStatusCode statusCode)
+    {
+        var response = new Mock<IApiResponse<CollectionResponse<SponsorSummaryResponse>>>(MockBehavior.Strict);
+        response.Setup(r => r.IsSuccessStatusCode).Returns(false);
+        response.Setup(r => r.StatusCode).Returns(statusCode);
+        response.Setup(r => r.Content).Returns((CollectionResponse<SponsorSummaryResponse>?)null);
+
+        _mockApi
+            .Setup(x => x.ListActiveSponsorsAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(response.Object);
+    }
+}

--- a/tests/e2e/About.spec.ts
+++ b/tests/e2e/About.spec.ts
@@ -1,0 +1,32 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('About page', () => {
+  test.use({ viewport: { width: 1200, height: 800 } });
+
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/about');
+    await page.waitForSelector('#about-title-sponsor-name');
+  });
+
+  test('renders the page header', async ({ page }) => {
+    await expect(page.locator('h1')).toContainText('About NEBA');
+  });
+
+  test('displays the title sponsor from API', async ({ page }) => {
+    await expect(page.locator('#about-title-sponsor-name')).toContainText('Acme Bowling Supply');
+  });
+
+  test('displays the premier partners section', async ({ page }) => {
+    await expect(page.locator('.sponsor-card-premier')).toHaveCount(1);
+  });
+
+  test('does not display standard-tier sponsors', async ({ page }) => {
+    await expect(page.locator('text=Regional Lanes')).not.toBeVisible();
+  });
+
+  test('navigates to sponsor detail when premier card is clicked', async ({ page }) => {
+    await page.locator('.sponsor-card-premier').click();
+    await page.waitForSelector('.sponsor-detail');
+    await expect(page).toHaveURL(/\/sponsors\/pro-shop-plus/);
+  });
+});


### PR DESCRIPTION
## Summary

- **About section** — adds three new public-facing pages (`/about`, `/about/faq`, `/about/things-to-know`) covering NEBA's history, mission, tournament format, sponsors, rules, and FAQs
- Nav "About" dropdown wired up with links to all three pages and dividers separating content from Bylaws
- Shared `page-title-bar` CSS extracted to `app.css` so the hero header style is consistent across all three pages
- bUnit and Playwright tests cover the new pages

## What Changed

### Blazor (`Neba.Website.Server`)

- **`About/About.razor`** (`/about`) — main landing page; stats row (60+ years, 1,000+ events, 500+ bowlers), About/Mission panels, Tournament Format flow, qualifications detail, Entry Fee table, sponsors grid (via `ISponsorsApi`), and links to FAQ / Things to Know
- **`About/About.razor.css`** — scoped styles for the stats cards, format flow, entry fee table, and sponsor grid
- **`About/Faq.razor`** (`/about/faq`) — static FAQ grouped by category (Membership & Eligibility, Tournament Format, Match Play, Prizes, Rules) using native `<details>`/`<summary>` accordion
- **`About/Faq.razor.css`** — scoped styles for FAQ categories, items, and body
- **`About/ThingsToKnow.razor`** (`/about/things-to-know`) — tournament day reference page covering arrival, check-in, membership, equipment, scoring, match play, and contact info with numbered sections
- **`About/ThingsToKnow.razor.css`** — scoped styles for numbered section headers, rule lists, fine/contact badges, and criteria lists
- **`Layout/NavMenu.razor`** — About dropdown now includes "About NEBA", "FAQ", "Things to Know" links with dividers; "About NEBA" uses `NavLinkMatch.All`
- **`wwwroot/app.css`** — shared `.page-title-bar` / `.page-title-inner` styles (gradient hero header + responsive breakpoint) moved from per-component CSS into global sheet

### Tests

- **`tests/Neba.Website.Tests/About/AboutPageTests.cs`** — bUnit tests for `About.razor`: renders stats, mission, format flow, qualifications, entry fees, sponsors (loaded and error states), and navigation links
- **`tests/e2e/About.spec.ts`** — Playwright E2E tests: page title, stats cards, nav links to FAQ and Things to Know, and sponsor section visibility

## Test Plan

- [ ] `dotnet test --filter "Category=Unit"` — all unit tests pass
- [ ] `dotnet test --filter "Component=About"` — About component tests pass
- [ ] `npm run test:e2e` — E2E About spec passes
- [ ] Navigate to `/about` and verify stats, format, sponsors section, and links to FAQ / Things to Know
- [ ] Navigate to `/about/faq` and verify accordion sections expand/collapse
- [ ] Navigate to `/about/things-to-know` and verify all numbered sections render
- [ ] Verify "About" nav dropdown shows "About NEBA", "FAQ", "Things to Know" (and Bylaws) with dividers
- [ ] Verify responsive layout at mobile width (≤640px) — page title bar and stats cards
