### PR TITLE
Feature Flagging

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -4,7 +4,8 @@
       "Bash(dotnet-stryker --verbosity diagnostic)",
       "Bash(dotnet-stryker --verbosity Trace)",
       "Bash(tests/Neba.Api.Tests/bin/Debug/net10.0/Neba.Api.Tests.dll)",
-      "Bash(dotnet-stryker)"
+      "Bash(dotnet-stryker)",
+      "Bash(ilspycmd -t \"Microsoft.FeatureManagement.FeatureFilterEvaluationContext\" /Users/kippermand/.nuget/packages/microsoft.featuremanagement/4.6.0/lib/netstandard2.1/Microsoft.FeatureManagement.dll)"
     ]
   }
 }

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -57,6 +57,7 @@
     <PackageVersion Include="Microsoft.Extensions.Diagnostics.Testing" Version="10.7.0" />
     <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.7.0" />
     <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery" Version="10.7.0" />
+    <PackageVersion Include="Microsoft.FeatureManagement" Version="4.6.0" />
     <PackageVersion Include="Microsoft.FeatureManagement.AspNetCore" Version="4.6.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
     <!-- Hard-pinned to 2.x: Microsoft.AspNetCore.OpenApi's XmlCommentGenerator emits code against the

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -57,6 +57,7 @@
     <PackageVersion Include="Microsoft.Extensions.Diagnostics.Testing" Version="10.7.0" />
     <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.7.0" />
     <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery" Version="10.7.0" />
+    <PackageVersion Include="Microsoft.FeatureManagement.AspNetCore" Version="4.6.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
     <!-- Hard-pinned to 2.x: Microsoft.AspNetCore.OpenApi's XmlCommentGenerator emits code against the
          2.x object model (settable IOpenApiMediaType.Example); 3.x made it read-only and breaks the build. -->

--- a/docs/plans/feature-flagging.md
+++ b/docs/plans/feature-flagging.md
@@ -1,0 +1,216 @@
+# Feature Flagging Plan
+
+## Overview
+
+Adopt `Microsoft.FeatureManagement` as the feature-flagging library for both `Neba.Api` and `Neba.Website.Server`. Flags are defined in `appsettings.json` (no Azure App Configuration for now — revisit if runtime toggling without redeploy becomes a real need). This plan covers two steps:
+
+1. **Infrastructure**: bring in the library, wire up configuration binding, register feature management in both the API and the Website composition roots, and establish the pattern (custom filters, naming, config shape) that all future flags will follow.
+2. **First flag — `UserRegistration`**: gate the existing `POST register` endpoint (`src/Neba.Api/Security/Register/RegisterEndpoint.cs`) so that only a *caller* whose JWT `email` claim is `tech@bowlneba.com` can invoke it. There is no UI for registration yet, so this is API-only enforcement.
+
+**Why Microsoft.FeatureManagement**: first-party library, integrates natively with `IConfiguration` (matches this repo's existing options pattern), supports custom `IFeatureFilter` implementations for the email-based targeting we need, and has an ASP.NET Core package (`Microsoft.FeatureManagement.AspNetCore`) with `IVariantFeatureManager` for use in FastEndpoints and Blazor alike.
+
+---
+
+## Gating mechanism: optional-auth claim check, `AllowAnonymous()` stays as-is
+
+`RegisterEndpoint` keeps `AllowAnonymous()` — no policy requirement is added, and the route remains reachable without a token. This is intentional and treated as an **interim** approach until real self-service registration rules exist: the endpoint still runs ASP.NET Core's authentication middleware even under `AllowAnonymous()` (that attribute only skips *authorization*, not authentication), so if the caller happens to send a valid bearer token, `User` is populated with its claims; if no token is sent, `User.Identity?.IsAuthenticated` is `false` and there are no claims.
+
+The feature check reads the caller's JWT `email` claim (`User.FindFirstValue(JwtRegisteredClaimNames.Email)`) when present and compares it to the allow-list:
+
+- Caller sends a valid token with `email == tech@bowlneba.com` → flag enabled, registration proceeds.
+- Caller sends no token, an invalid token, or a token with a different email → flag disabled → 404.
+
+`JwtTokenService.CreateTokenPair` (`src/Neba.Api/Security/JwtTokenService.cs:25`) already emits `JwtRegisteredClaimNames.Email` on every token, so no token-shape change is needed. This is a stopgap: it relies on `tech@bowlneba.com` already being a logged-in user calling an anonymous endpoint with their token attached, which is unusual but requires no endpoint/policy changes and is easy to relax later (e.g. once a real "who can invite new members" rule exists).
+
+---
+
+## Phase 1: Bring in Microsoft.FeatureManagement + basic structure
+
+### 1.1 Package references
+
+Add to `Directory.Packages.props`:
+
+```xml
+<PackageVersion Include="Microsoft.FeatureManagement" Version="4.0.0" />
+<PackageVersion Include="Microsoft.FeatureManagement.AspNetCore" Version="4.0.0" />
+```
+
+(Pin to whatever the latest stable 4.x release is at implementation time — confirm compatibility with `net10.0`.)
+
+Add `<PackageReference Include="Microsoft.FeatureManagement.AspNetCore" />` to:
+
+- `src/Neba.Api/Neba.Api.csproj`
+- `src/Neba.Website.Server/Neba.Website.Server.csproj`
+
+### 1.2 Configuration shape
+
+Standard `Microsoft.FeatureManagement` config section, in each project's `appsettings.json`:
+
+```json
+{
+  "FeatureManagement": {
+    "UserRegistration": {
+      "EnabledFor": [
+        {
+          "Name": "AllowedEmail",
+          "Parameters": {
+            "AllowedEmails": [ "tech@bowlneba.com" ]
+          }
+        }
+      ]
+    }
+  }
+}
+```
+
+Flag names are `PascalCase` and match a `static class FeatureFlags` constants holder (avoid magic strings), mirroring how `SecurityConfiguration.AuthenticatedPolicy` is a const today.
+
+- `src/Neba.Api/FeatureFlags.cs` — `internal static class FeatureFlags { internal const string UserRegistration = "UserRegistration"; }`
+- Mirror in `Neba.Website.Server` once a UI flag exists (Phase 1 sets up the pattern; no UI flags yet in this plan — see "UI feature flagging" note below).
+
+### 1.3 Custom feature filter — `AllowedEmailFilter`
+
+Location: `src/Neba.Api/Infrastructure/FeatureManagement/AllowedEmailFilter.cs` (new `Infrastructure/FeatureManagement` folder — cross-cutting, not owned by any single feature).
+
+```csharp
+[FilterAlias("AllowedEmail")]
+internal sealed class AllowedEmailFilter : IContextualFeatureFilter<AllowedEmailContext>
+{
+    public Task<bool> EvaluateAsync(FeatureFilterEvaluationContext context, AllowedEmailContext appContext)
+    {
+        if (string.IsNullOrEmpty(appContext.Email))
+            return Task.FromResult(false);
+
+        var settings = context.Parameters.Get<AllowedEmailFilterSettings>() ?? new AllowedEmailFilterSettings();
+        var allowed = settings.AllowedEmails.Contains(appContext.Email, StringComparer.OrdinalIgnoreCase);
+        return Task.FromResult(allowed);
+    }
+}
+
+internal sealed class AllowedEmailContext
+{
+    public string? Email { get; init; }
+}
+
+internal sealed record AllowedEmailFilterSettings
+{
+    public IReadOnlyCollection<string> AllowedEmails { get; init; } = [];
+}
+```
+
+`Email` is nullable because `RegisterEndpoint` stays `AllowAnonymous()` (see Phase 2) — an unauthenticated caller has no claim to supply.
+
+Using `IContextualFeatureFilter<TContext>` (not the plain `IFeatureFilter`) lets the endpoint pass the caller's email explicitly — pulled from `User` claims when a token is present, or `null` when the request is fully anonymous (see Phase 2).
+
+### 1.4 Registration
+
+New `src/Neba.Api/Infrastructure/FeatureManagement/FeatureManagementConfiguration.cs`, following the existing `extension` syntax used by `InfrastructureConfiguration.cs`:
+
+```csharp
+namespace Neba.Api.Infrastructure.FeatureManagement;
+
+internal static class FeatureManagementConfiguration
+{
+    extension(WebApplicationBuilder builder)
+    {
+        public WebApplicationBuilder AddFeatureManagement()
+        {
+            builder.Services
+                .AddFeatureManagement(builder.Configuration.GetSection("FeatureManagement"))
+                .AddFeatureFilter<AllowedEmailFilter>();
+
+            return builder;
+        }
+    }
+}
+```
+
+Wire into `src/Neba.Api/Program.cs` alongside the existing chain:
+
+```csharp
+builder.AddInfrastructure().AddSecurity().AddFeatureManagement();
+```
+
+Same pattern added to `Neba.Website.Server/Program.cs` (`builder.Services.AddFeatureManagement(...)`) even though Phase 2 has no UI flag yet — this satisfies "keep in mind we'll want feature flagging on the UI as well" by establishing the wiring now rather than bolting it on later.
+
+### 1.5 Testing
+
+- Unit test `AllowedEmailFilterTests` — evaluate with matching email (true), non-matching (false), case-insensitive match, empty `AllowedEmails` (false). Use `[UnitTest]`/`[Component("FeatureManagement")]` traits per repo conventions.
+- No integration test needed for Phase 1 registration wiring itself (covered indirectly by Phase 2's endpoint tests).
+
+---
+
+## Phase 2: First flag — `UserRegistration`
+
+### 2.1 Where the check happens
+
+Per the endpoint-level decision: check the flag inside `RegisterEndpoint.HandleAsync`, before dispatching to `RegisterCommandHandler`. `Configure()` is unchanged — `AllowAnonymous()` stays. The email passed to the filter comes from the caller's claims if a token was sent, or `null` otherwise (no token → no claim → filter evaluates false). On a disallowed/missing email, return **404 Not Found** (hide that the endpoint exists — there's no UI and it isn't meant to be discoverable yet).
+
+```csharp
+public override async Task HandleAsync(RegisterRequest req, CancellationToken ct)
+{
+    var callerEmail = User.FindFirstValue(JwtRegisteredClaimNames.Email);
+    var context = new AllowedEmailContext { Email = callerEmail };
+    if (!await _featureManager.IsEnabledAsync(FeatureFlags.UserRegistration, context))
+    {
+        await Send.NotFoundAsync(ct);
+        // Stryker disable once Statement
+        return;
+    }
+
+    var command = new RegisterCommand { Email = req.Input.Email, Password = req.Input.Password };
+    // ...unchanged...
+}
+```
+
+`AllowedEmailContext.Email` becomes nullable (`string?`) to accommodate the no-token case, and `AllowedEmailFilter.EvaluateAsync` treats `null`/empty as never matching (no allocation of a "null" comparison edge case — `Contains` against a null needle should short-circuit to `false` explicitly rather than relying on `Contains(null)` behavior).
+
+`RegisterEndpoint` gains a constructor dependency on `IVariantFeatureManager` (or `IFeatureManager` — confirm which is idiomatic for contextual filters in the pinned package version during implementation).
+
+### 2.2 Files touched
+
+- `src/Neba.Api/Security/Register/RegisterEndpoint.cs` — add flag check (as above); `Configure()` untouched
+- `src/Neba.Api/Security/Register/RegisterEndpointTests.cs` (or wherever existing endpoint tests live) — add cases: no bearer token → 404 before handler is ever invoked; token present but email doesn't match → 404; token present with `email == tech@bowlneba.com` → falls through to existing success/error branches. `MockBehavior.Strict` on the command handler mock proves it's never invoked in the blocked cases.
+- `src/Neba.Api/Infrastructure/FeatureManagement/AllowedEmailFilter.cs` — null/empty-email handling (see 2.1)
+- `src/Neba.Api/appsettings.json` — add the `FeatureManagement:UserRegistration` section (see 1.2)
+- `src/Neba.Api/Security/Register/RegisterSummary.cs` — add `ProducesProblemDetails(StatusCodes.Status404NotFound)` (or equivalent `Produces(404)`) to the OpenAPI description per the API Endpoint Checklist
+
+### 2.3 Out of scope for this phase
+
+- No UI page for registration yet — nothing changes in `Neba.Website.Server`
+- No Azure App Configuration — flags are redeploy-to-change for now
+- No new authorization policy or `Configure()` changes — this is deliberately a stopgap built on optional auth, not a real authorization rule (see the gating-mechanism section above)
+- No admin UI to toggle flags at runtime
+
+---
+
+## Future: UI feature flagging (not in this plan's scope, noted for follow-up)
+
+Phase 1 registers `Microsoft.FeatureManagement` in `Neba.Website.Server` so the wiring exists, but no Blazor-specific pattern (e.g. a `<FeatureGate>` component wrapping `IVariantFeatureManager`, or flag-aware `AuthenticationStateProvider` claims) is designed yet. When the first UI flag is needed:
+
+- Decide whether Blazor components check `IVariantFeatureManager` directly (server-rendered, simplest) or need a client-visible flag (WASM/interactive client component in `Neba.Website.Client` — would need the flag state passed down via a Blazor cascading parameter or fetched from an API endpoint, since `Neba.Website.Client` can't read server-side `appsettings.json` directly).
+- Revisit whether Azure App Configuration becomes worthwhile once flags need to change without a redeploy across both API and UI simultaneously.
+
+---
+
+## Summary of new/changed files
+
+**New:**
+
+- `src/Neba.Api/FeatureFlags.cs`
+- `src/Neba.Api/Infrastructure/FeatureManagement/AllowedEmailFilter.cs`
+- `src/Neba.Api/Infrastructure/FeatureManagement/FeatureManagementConfiguration.cs`
+- `tests/Neba.Api.Tests/Infrastructure/FeatureManagement/AllowedEmailFilterTests.cs`
+
+**Changed:**
+
+- `Directory.Packages.props` — add `Microsoft.FeatureManagement` + `.AspNetCore`
+- `src/Neba.Api/Neba.Api.csproj` — package reference
+- `src/Neba.Website.Server/Neba.Website.Server.csproj` — package reference
+- `src/Neba.Api/Program.cs` — `.AddFeatureManagement()` in the builder chain
+- `src/Neba.Website.Server/Program.cs` — `AddFeatureManagement()` registration
+- `src/Neba.Api/appsettings.json` — `FeatureManagement` section
+- `src/Neba.Website.Server/appsettings.json` — empty/placeholder `FeatureManagement` section
+- `src/Neba.Api/Security/Register/RegisterEndpoint.cs` — flag check + 404 path
+- `src/Neba.Api/Security/Register/RegisterSummary.cs` — document 404 response
+- Register endpoint test file — new test cases for gated/ungated email

--- a/docs/plans/feature-flagging.md
+++ b/docs/plans/feature-flagging.md
@@ -65,16 +65,21 @@ Standard `Microsoft.FeatureManagement` config section, in each project's `appset
 
 Flag names are `PascalCase` and match a `static class FeatureFlags` constants holder (avoid magic strings), mirroring how `SecurityConfiguration.AuthenticatedPolicy` is a const today.
 
-- `src/Neba.Api/FeatureFlags.cs` — `internal static class FeatureFlags { internal const string UserRegistration = "UserRegistration"; }`
-- Mirror in `Neba.Website.Server` once a UI flag exists (Phase 1 sets up the pattern; no UI flags yet in this plan — see "UI feature flagging" note below).
+- `src/Neba.Api.Contracts/FeatureFlags.cs` — `public static class FeatureFlags { public const string UserRegistration = "UserRegistration"; }`. **Public and in `Contracts`, not `internal` in `Neba.Api`** — `Neba.Website.Server` already references `Neba.Api.Contracts` (`Neba.Website.Server.csproj:18`), and flag names need to be usable from both processes so a UI check and an API check for the same flag can't drift.
 
 ### 1.3 Custom feature filter — `AllowedEmailFilter`
 
-Location: `src/Neba.Api/Infrastructure/FeatureManagement/AllowedEmailFilter.cs` (new `Infrastructure/FeatureManagement` folder — cross-cutting, not owned by any single feature).
+**Same sharing concern applies to the filter, not just the flag name.** `Microsoft.FeatureManagement` filters are registered into each process's own DI container — `Neba.Api` and `Neba.Website.Server` are separate processes with separate `appsettings.json` and separate `AddFeatureManagement()` calls. If a Blazor page ever wants to gate on "is the current caller's email on the allow-list" (e.g. hiding an admin nav link), the Website needs the *same filter type* registered in its own container — reusing `Neba.Api`'s `internal` filter wouldn't be visible across the assembly boundary. So `AllowedEmailFilter` (and its context/settings types) live in `Neba.Api.Contracts` too, next to `FeatureFlags`, as `public`:
+
+Location: `src/Neba.Api.Contracts/FeatureManagement/AllowedEmailFilter.cs` (new `FeatureManagement` folder in `Contracts` — shared, not owned by either process).
+
+`Neba.Api.Contracts.csproj` needs a new `<PackageReference Include="Microsoft.FeatureManagement" />` (the core package, not `.AspNetCore` — `Contracts` shouldn't depend on ASP.NET Core hosting types).
 
 ```csharp
+namespace Neba.Api.Contracts.FeatureManagement;
+
 [FilterAlias("AllowedEmail")]
-internal sealed class AllowedEmailFilter : IContextualFeatureFilter<AllowedEmailContext>
+public sealed class AllowedEmailFilter : IContextualFeatureFilter<AllowedEmailContext>
 {
     public Task<bool> EvaluateAsync(FeatureFilterEvaluationContext context, AllowedEmailContext appContext)
     {
@@ -87,26 +92,30 @@ internal sealed class AllowedEmailFilter : IContextualFeatureFilter<AllowedEmail
     }
 }
 
-internal sealed class AllowedEmailContext
+public sealed class AllowedEmailContext
 {
     public string? Email { get; init; }
 }
 
-internal sealed record AllowedEmailFilterSettings
+public sealed record AllowedEmailFilterSettings
 {
     public IReadOnlyCollection<string> AllowedEmails { get; init; } = [];
 }
 ```
 
-`Email` is nullable because `RegisterEndpoint` stays `AllowAnonymous()` (see Phase 2) — an unauthenticated caller has no claim to supply.
+`Email` is nullable because `RegisterEndpoint` stays `AllowAnonymous()` (see Phase 2) — an unauthenticated caller has no claim to supply. All four types are `public` (not `internal`) since they cross the `Neba.Api` / `Neba.Website.Server` assembly boundary via `Neba.Api.Contracts`.
 
 Using `IContextualFeatureFilter<TContext>` (not the plain `IFeatureFilter`) lets the endpoint pass the caller's email explicitly — pulled from `User` claims when a token is present, or `null` when the request is fully anonymous (see Phase 2).
 
 ### 1.4 Registration
 
-New `src/Neba.Api/Infrastructure/FeatureManagement/FeatureManagementConfiguration.cs`, following the existing `extension` syntax used by `InfrastructureConfiguration.cs`:
+Both processes register `Microsoft.FeatureManagement` plus the shared `AllowedEmailFilter` from `Neba.Api.Contracts` — this is not forward-looking scaffolding, it's needed now so the Website *can* reuse the same filter/flag the moment a UI check is added, without a second implementation to keep in sync.
+
+`src/Neba.Api/Infrastructure/FeatureManagement/FeatureManagementConfiguration.cs`, following the existing `extension` syntax used by `InfrastructureConfiguration.cs`:
 
 ```csharp
+using Neba.Api.Contracts.FeatureManagement;
+
 namespace Neba.Api.Infrastructure.FeatureManagement;
 
 internal static class FeatureManagementConfiguration
@@ -131,7 +140,15 @@ Wire into `src/Neba.Api/Program.cs` alongside the existing chain:
 builder.AddInfrastructure().AddSecurity().AddFeatureManagement();
 ```
 
-Same pattern added to `Neba.Website.Server/Program.cs` (`builder.Services.AddFeatureManagement(...)`) even though Phase 2 has no UI flag yet — this satisfies "keep in mind we'll want feature flagging on the UI as well" by establishing the wiring now rather than bolting it on later.
+`src/Neba.Website.Server/Program.cs` gets the equivalent call (mirroring whatever local extension-method convention `Neba.Website.Server` already uses for its own registrations, e.g. `AddApiServices`/`AddAccountServices`), registering `Microsoft.FeatureManagement` against its own `appsettings.json` `FeatureManagement` section and the same `AllowedEmailFilter`:
+
+```csharp
+builder.Services
+    .AddFeatureManagement(builder.Configuration.GetSection("FeatureManagement"))
+    .AddFeatureFilter<AllowedEmailFilter>();
+```
+
+Each process still evaluates the flag independently against its *own* `appsettings.json` — the config section (allow-list) needs to be kept in sync between `src/Neba.Api/appsettings.json` and `src/Neba.Website.Server/appsettings.json` by hand for now (no shared/centralized config source yet — see the Azure App Configuration note below).
 
 ### 1.5 Testing
 
@@ -171,8 +188,9 @@ public override async Task HandleAsync(RegisterRequest req, CancellationToken ct
 
 - `src/Neba.Api/Security/Register/RegisterEndpoint.cs` — add flag check (as above); `Configure()` untouched
 - `src/Neba.Api/Security/Register/RegisterEndpointTests.cs` (or wherever existing endpoint tests live) — add cases: no bearer token → 404 before handler is ever invoked; token present but email doesn't match → 404; token present with `email == tech@bowlneba.com` → falls through to existing success/error branches. `MockBehavior.Strict` on the command handler mock proves it's never invoked in the blocked cases.
-- `src/Neba.Api/Infrastructure/FeatureManagement/AllowedEmailFilter.cs` — null/empty-email handling (see 2.1)
+- `src/Neba.Api.Contracts/FeatureManagement/AllowedEmailFilter.cs` — null/empty-email handling (see 2.1); this file is created in Phase 1, not new in Phase 2
 - `src/Neba.Api/appsettings.json` — add the `FeatureManagement:UserRegistration` section (see 1.2)
+- `src/Neba.Website.Server/appsettings.json` — add the same `FeatureManagement:UserRegistration` section, kept in sync by hand (see 1.4)
 - `src/Neba.Api/Security/Register/RegisterSummary.cs` — add `ProducesProblemDetails(StatusCodes.Status404NotFound)` (or equivalent `Produces(404)`) to the OpenAPI description per the API Endpoint Checklist
 
 ### 2.3 Out of scope for this phase
@@ -186,10 +204,11 @@ public override async Task HandleAsync(RegisterRequest req, CancellationToken ct
 
 ## Future: UI feature flagging (not in this plan's scope, noted for follow-up)
 
-Phase 1 registers `Microsoft.FeatureManagement` in `Neba.Website.Server` so the wiring exists, but no Blazor-specific pattern (e.g. a `<FeatureGate>` component wrapping `IVariantFeatureManager`, or flag-aware `AuthenticationStateProvider` claims) is designed yet. When the first UI flag is needed:
+Phase 1 registers `Microsoft.FeatureManagement` and the shared `AllowedEmailFilter` in `Neba.Website.Server` so both the package wiring and the filter logic already exist there — a Blazor page can call `IVariantFeatureManager.IsEnabledAsync(FeatureFlags.UserRegistration, new AllowedEmailContext { Email = ... })` today using the current user's email from the Blazor auth cookie claims (`identity-implementation.md` confirms the cookie already carries an `email` claim). What's still undesigned is the *Blazor-specific ergonomics* around that call:
 
-- Decide whether Blazor components check `IVariantFeatureManager` directly (server-rendered, simplest) or need a client-visible flag (WASM/interactive client component in `Neba.Website.Client` — would need the flag state passed down via a Blazor cascading parameter or fetched from an API endpoint, since `Neba.Website.Client` can't read server-side `appsettings.json` directly).
-- Revisit whether Azure App Configuration becomes worthwhile once flags need to change without a redeploy across both API and UI simultaneously.
+- No `<FeatureGate>`-style component wrapping `IVariantFeatureManager` yet — each page/component would call the feature manager directly for now.
+- `Neba.Website.Server` is server-rendered, so `IVariantFeatureManager` is trivially available via DI in `@code` blocks. A client-visible flag (interactive WASM component in `Neba.Website.Client`) is a different problem — `Neba.Website.Client` can't read server-side `appsettings.json` or resolve server-only services directly, so that case would need the flag state passed down via a cascading parameter or fetched from an API endpoint. Out of scope until a client-rendered flag is actually needed.
+- Revisit whether Azure App Configuration becomes worthwhile once flags need to change without a redeploy across both API and UI simultaneously — right now `appsettings.json` in each project must be kept in sync by hand (Phase 1, 1.4).
 
 ---
 
@@ -197,20 +216,21 @@ Phase 1 registers `Microsoft.FeatureManagement` in `Neba.Website.Server` so the 
 
 **New:**
 
-- `src/Neba.Api/FeatureFlags.cs`
-- `src/Neba.Api/Infrastructure/FeatureManagement/AllowedEmailFilter.cs`
+- `src/Neba.Api.Contracts/FeatureFlags.cs` — already created (public flag-name constants, shared by both processes)
+- `src/Neba.Api.Contracts/FeatureManagement/AllowedEmailFilter.cs` — filter + `AllowedEmailContext` + `AllowedEmailFilterSettings`, public, shared by both processes
 - `src/Neba.Api/Infrastructure/FeatureManagement/FeatureManagementConfiguration.cs`
-- `tests/Neba.Api.Tests/Infrastructure/FeatureManagement/AllowedEmailFilterTests.cs`
+- `tests/Neba.Api.Tests/Infrastructure/FeatureManagement/AllowedEmailFilterTests.cs` (or under a `Neba.Api.Contracts.Tests` project if one exists — confirm at implementation time)
 
 **Changed:**
 
 - `Directory.Packages.props` — add `Microsoft.FeatureManagement` + `.AspNetCore`
-- `src/Neba.Api/Neba.Api.csproj` — package reference
-- `src/Neba.Website.Server/Neba.Website.Server.csproj` — package reference
+- `src/Neba.Api.Contracts/Neba.Api.Contracts.csproj` — `Microsoft.FeatureManagement` package reference (core package only)
+- `src/Neba.Api/Neba.Api.csproj` — `Microsoft.FeatureManagement.AspNetCore` package reference
+- `src/Neba.Website.Server/Neba.Website.Server.csproj` — `Microsoft.FeatureManagement.AspNetCore` package reference
 - `src/Neba.Api/Program.cs` — `.AddFeatureManagement()` in the builder chain
-- `src/Neba.Website.Server/Program.cs` — `AddFeatureManagement()` registration
+- `src/Neba.Website.Server/Program.cs` — equivalent `AddFeatureManagement()` registration, using the shared `AllowedEmailFilter`
 - `src/Neba.Api/appsettings.json` — `FeatureManagement` section
-- `src/Neba.Website.Server/appsettings.json` — empty/placeholder `FeatureManagement` section
+- `src/Neba.Website.Server/appsettings.json` — same `FeatureManagement` section, kept in sync by hand
 - `src/Neba.Api/Security/Register/RegisterEndpoint.cs` — flag check + 404 path
 - `src/Neba.Api/Security/Register/RegisterSummary.cs` — document 404 response
 - Register endpoint test file — new test cases for gated/ungated email

--- a/src/Neba.Api.Contracts/FeatureFlags.cs
+++ b/src/Neba.Api.Contracts/FeatureFlags.cs
@@ -1,0 +1,12 @@
+namespace Neba.Api.Contracts;
+
+/// <summary>
+/// Contains the feature flags used in the application.
+/// </summary>
+public static class FeatureFlags
+{
+    /// <summary>
+    /// Indicates whether the user registration feature is enabled.
+    /// </summary>
+    public const string UserRegistration = "UserRegistration";
+}

--- a/src/Neba.Api.Contracts/FeatureManagement/AllowedEmailContext.cs
+++ b/src/Neba.Api.Contracts/FeatureManagement/AllowedEmailContext.cs
@@ -1,6 +1,12 @@
 namespace Neba.Api.Contracts.FeatureManagement;
 
-internal sealed record AllowedEmailContext
+/// <summary>
+/// Represents the context for the AllowedEmail feature filter, containing the user's email address.
+/// </summary>
+public sealed record AllowedEmailContext
 {
+    /// <summary>
+    /// Gets or sets the email address of the user for whom the feature is being evaluated.
+    /// </summary>
     public string? Email { get; init; }
 }

--- a/src/Neba.Api.Contracts/FeatureManagement/AllowedEmailContext.cs
+++ b/src/Neba.Api.Contracts/FeatureManagement/AllowedEmailContext.cs
@@ -1,0 +1,6 @@
+namespace Neba.Api.Contracts.FeatureManagement;
+
+internal sealed record AllowedEmailContext
+{
+    public string? Email { get; init; }
+}

--- a/src/Neba.Api.Contracts/FeatureManagement/AllowedEmailContext.cs
+++ b/src/Neba.Api.Contracts/FeatureManagement/AllowedEmailContext.cs
@@ -6,7 +6,7 @@ namespace Neba.Api.Contracts.FeatureManagement;
 public sealed record AllowedEmailContext
 {
     /// <summary>
-    /// Gets or sets the email address of the user for whom the feature is being evaluated.
+    /// Gets the email address of the user for whom the feature is being evaluated.
     /// </summary>
     public string? Email { get; init; }
 }

--- a/src/Neba.Api.Contracts/FeatureManagement/AllowedEmailFilter.cs
+++ b/src/Neba.Api.Contracts/FeatureManagement/AllowedEmailFilter.cs
@@ -1,0 +1,24 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.FeatureManagement;
+
+namespace Neba.Api.Contracts.FeatureManagement;
+
+[FilterAlias("AllowedEmail")]
+internal sealed class AllowedEmailFilter
+    : IContextualFeatureFilter<AllowedEmailContext>
+{
+    public Task<bool> EvaluateAsync(FeatureFilterEvaluationContext featureFilterContext, AllowedEmailContext appContext)
+    {
+        if (string.IsNullOrEmpty(appContext.Email))
+        {
+            return Task.FromResult(false);
+        }
+
+        var settings = featureFilterContext.Parameters.Get<AllowedEmailFilterSettings>()
+            ?? new();
+
+        var allowed = settings.AllowedEmails.Contains(appContext.Email);
+
+        return Task.FromResult(allowed);
+    }
+}

--- a/src/Neba.Api.Contracts/FeatureManagement/AllowedEmailFilter.cs
+++ b/src/Neba.Api.Contracts/FeatureManagement/AllowedEmailFilter.cs
@@ -15,7 +15,7 @@ public sealed class AllowedEmailFilter
     {
         ArgumentNullException.ThrowIfNull(featureFilterContext);
         ArgumentNullException.ThrowIfNull(appContext);
-        
+
         if (string.IsNullOrEmpty(appContext.Email))
         {
             return Task.FromResult(false);

--- a/src/Neba.Api.Contracts/FeatureManagement/AllowedEmailFilter.cs
+++ b/src/Neba.Api.Contracts/FeatureManagement/AllowedEmailFilter.cs
@@ -3,12 +3,19 @@ using Microsoft.FeatureManagement;
 
 namespace Neba.Api.Contracts.FeatureManagement;
 
+/// <summary>
+/// A feature filter that allows or denies access to a feature based on the user's email address.
+/// </summary>
 [FilterAlias("AllowedEmail")]
-internal sealed class AllowedEmailFilter
+public sealed class AllowedEmailFilter
     : IContextualFeatureFilter<AllowedEmailContext>
 {
+    /// <inheritdoc />
     public Task<bool> EvaluateAsync(FeatureFilterEvaluationContext featureFilterContext, AllowedEmailContext appContext)
     {
+        ArgumentNullException.ThrowIfNull(featureFilterContext);
+        ArgumentNullException.ThrowIfNull(appContext);
+        
         if (string.IsNullOrEmpty(appContext.Email))
         {
             return Task.FromResult(false);

--- a/src/Neba.Api.Contracts/FeatureManagement/AllowedEmailFilter.cs
+++ b/src/Neba.Api.Contracts/FeatureManagement/AllowedEmailFilter.cs
@@ -24,7 +24,7 @@ public sealed class AllowedEmailFilter
         var settings = featureFilterContext.Parameters.Get<AllowedEmailFilterSettings>()
             ?? new();
 
-        var allowed = settings.AllowedEmails.Contains(appContext.Email);
+        var allowed = settings.AllowedEmails.Contains(appContext.Email, StringComparer.OrdinalIgnoreCase);
 
         return Task.FromResult(allowed);
     }

--- a/src/Neba.Api.Contracts/FeatureManagement/AllowedEmailFilterSettings.cs
+++ b/src/Neba.Api.Contracts/FeatureManagement/AllowedEmailFilterSettings.cs
@@ -1,0 +1,6 @@
+namespace Neba.Api.Contracts.FeatureManagement;
+
+internal sealed record AllowedEmailFilterSettings
+{
+    public IReadOnlyCollection<string> AllowedEmails { get; init; } = [];
+}

--- a/src/Neba.Api.Contracts/FeatureManagement/AllowedEmailFilterSettings.cs
+++ b/src/Neba.Api.Contracts/FeatureManagement/AllowedEmailFilterSettings.cs
@@ -1,5 +1,8 @@
 namespace Neba.Api.Contracts.FeatureManagement;
 
+/// <summary>
+/// Settings for the AllowedEmail feature filter, containing the list of allowed email addresses.
+/// </summary>
 internal sealed record AllowedEmailFilterSettings
 {
     public IReadOnlyCollection<string> AllowedEmails { get; init; } = [];

--- a/src/Neba.Api.Contracts/FeatureManagement/FeatureFlags.cs
+++ b/src/Neba.Api.Contracts/FeatureManagement/FeatureFlags.cs
@@ -1,4 +1,4 @@
-namespace Neba.Api.Contracts;
+namespace Neba.Api.Contracts.FeatureManagement;
 
 /// <summary>
 /// Contains the feature flags used in the application.

--- a/src/Neba.Api.Contracts/Neba.Api.Contracts.csproj
+++ b/src/Neba.Api.Contracts/Neba.Api.Contracts.csproj
@@ -6,7 +6,12 @@
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Ardalis.SmartEnum" />
+    <PackageReference Include="Microsoft.FeatureManagement" />
     <PackageReference Include="Refit" />
   </ItemGroup>
-  
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="Neba.Api.Tests" />
+  </ItemGroup>
+
 </Project>

--- a/src/Neba.Api.Contracts/Neba.Api.Contracts.csproj
+++ b/src/Neba.Api.Contracts/Neba.Api.Contracts.csproj
@@ -10,8 +10,4 @@
     <PackageReference Include="Refit" />
   </ItemGroup>
 
-  <ItemGroup>
-    <InternalsVisibleTo Include="Neba.Api.Tests" />
-  </ItemGroup>
-
 </Project>

--- a/src/Neba.Api/FeatureManagement/FeatureManagementConfiguration.cs
+++ b/src/Neba.Api/FeatureManagement/FeatureManagementConfiguration.cs
@@ -1,0 +1,20 @@
+using Microsoft.FeatureManagement;
+
+using Neba.Api.Contracts.FeatureManagement;
+
+namespace Neba.Api.FeatureManagement;
+
+internal static class FeatureManagementConfiguration
+{
+    extension(WebApplicationBuilder builder)
+    {
+        public WebApplicationBuilder AddFeatureManagement()
+        {
+            builder.Services
+                .AddFeatureManagement(builder.Configuration.GetSection("FeatureManagement"))
+                .AddFeatureFilter<AllowedEmailFilter>();
+
+            return builder;
+        }
+    }
+}

--- a/src/Neba.Api/Neba.Api.csproj
+++ b/src/Neba.Api/Neba.Api.csproj
@@ -35,6 +35,7 @@
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" PrivateAssets="all" />
     <PackageReference Include="Microsoft.Extensions.Caching.Hybrid" />
+    <PackageReference Include="Microsoft.FeatureManagement.AspNetCore" />
     <PackageReference Include="Microsoft.OpenApi" />
     <PackageReference Include="Scalar.AspNetCore" />
     <PackageReference Include="Scrutor.AspNetCore" />

--- a/src/Neba.Api/Program.cs
+++ b/src/Neba.Api/Program.cs
@@ -5,6 +5,7 @@ using FastEndpoints;
 
 using Neba.Api;
 using Neba.Api.ErrorHandling;
+using Neba.Api.FeatureManagement;
 using Neba.Api.OpenApi;
 using Neba.Api.Security;
 using Neba.Api.Versioning;
@@ -31,7 +32,8 @@ builder.Services
 
 builder
     .AddInfrastructure()
-    .AddSecurity();
+    .AddSecurity()
+    .AddFeatureManagement();
 
 var app = builder.Build();
 

--- a/src/Neba.Api/Security/Register/RegisterEndpoint.cs
+++ b/src/Neba.Api/Security/Register/RegisterEndpoint.cs
@@ -1,3 +1,6 @@
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+
 using Asp.Versioning;
 
 using ErrorOr;
@@ -5,14 +8,20 @@ using ErrorOr;
 using FastEndpoints;
 using FastEndpoints.AspVersioning;
 
+using Microsoft.FeatureManagement;
+
+using Neba.Api.Contracts.FeatureManagement;
 using Neba.Api.Contracts.Security.Register;
 
 namespace Neba.Api.Security.Register;
 
-internal sealed class RegisterEndpoint(Messaging.ICommandHandler<RegisterCommand, Ulid> commandHandler)
+internal sealed class RegisterEndpoint(
+        Messaging.ICommandHandler<RegisterCommand, Ulid> commandHandler,
+        IFeatureManager featureManager)
     : Endpoint<RegisterRequest, RegisterResponse>
 {
     private readonly Messaging.ICommandHandler<RegisterCommand, Ulid> _commandHandler = commandHandler;
+    private readonly IFeatureManager _featureManager = featureManager;
 
     public override void Configure()
     {
@@ -35,6 +44,17 @@ internal sealed class RegisterEndpoint(Messaging.ICommandHandler<RegisterCommand
 
     public override async Task HandleAsync(RegisterRequest req, CancellationToken ct)
     {
+        var callerEmail = User.FindFirstValue(JwtRegisteredClaimNames.Email);
+        var context = new AllowedEmailContext {Email = callerEmail};
+
+        if (!await _featureManager.IsEnabledAsync(FeatureFlags.UserRegistration, context))
+        {
+            await Send.NotFoundAsync(ct);
+
+            // Stryker disable once Statement
+            return;
+        }
+
         var command = new RegisterCommand { Email = req.Input.Email, Password = req.Input.Password };
         var result = await _commandHandler.HandleAsync(command, ct);
 

--- a/src/Neba.Api/Security/Register/RegisterEndpoint.cs
+++ b/src/Neba.Api/Security/Register/RegisterEndpoint.cs
@@ -45,7 +45,7 @@ internal sealed class RegisterEndpoint(
     public override async Task HandleAsync(RegisterRequest req, CancellationToken ct)
     {
         var callerEmail = User.FindFirstValue(JwtRegisteredClaimNames.Email);
-        var context = new AllowedEmailContext {Email = callerEmail};
+        var context = new AllowedEmailContext { Email = callerEmail };
 
         if (!await _featureManager.IsEnabledAsync(FeatureFlags.UserRegistration, context))
         {

--- a/src/Neba.Api/Security/Register/RegisterEndpoint.cs
+++ b/src/Neba.Api/Security/Register/RegisterEndpoint.cs
@@ -38,6 +38,7 @@ internal sealed class RegisterEndpoint(
             .WithName("Register")
             .WithTags("Public")
             .Produces<RegisterResponse>(StatusCodes.Status201Created)
+            .ProducesProblemDetails(StatusCodes.Status404NotFound)
             .ProducesProblemDetails(StatusCodes.Status409Conflict)
             .ProducesProblemDetails(StatusCodes.Status422UnprocessableEntity));
     }

--- a/src/Neba.Api/Security/Register/RegisterSummary.cs
+++ b/src/Neba.Api/Security/Register/RegisterSummary.cs
@@ -17,6 +17,7 @@ internal sealed class RegisterSummary : Summary<RegisterEndpoint>
             contentType: MediaTypeNames.Application.Json,
             example: new RegisterResponse { UserId = "01JXXXXXXXXXXXXXXXXXXXXXXXXX" });
 
+        Response(404, "User registration is not enabled for this account.");
         Response(409, "An account with this email already exists.");
         Response(422, "Validation failed (invalid email format, password too short, etc.).");
     }

--- a/src/Neba.Api/appsettings.json
+++ b/src/Neba.Api/appsettings.json
@@ -2,6 +2,7 @@
   "ConnectionStrings": {
     "bowlneba": ""
   },
+
   "Logging": {
     "LogLevel": {
       "Default": "Information",
@@ -11,9 +12,26 @@
       "Hangfire": "Warning"
     }
   },
+
+  "FeatureManagement": {
+    "UserRegistration": {
+      "EnabledFor": [
+        {
+          "Name": "AllowedEmail",
+          "Parameters": {
+            "AllowedEmails": [
+              "tech@bowlneba.com"
+            ]
+          }
+        }
+      ]
+    }
+  },
+
   "SlowQuery": {
     "ThresholdMs": 1000
   },
+
   "Hangfire": {
     "WorkerCount": 3,
     "AutomaticRetryAttempts": 3,
@@ -21,6 +39,7 @@
     "DeletedJobsRetentionDays": 30,
     "FailedJobsRetentionDays": 90
   },
+
   "Google": {
     "ApplicationName": "bowlneba.com",
     "Credentials": {
@@ -44,12 +63,14 @@
       }
     ]
   },
+
   "EmailSettings": {
     "UserName": "tech@bowlneba.com",
     "FromAddress": "noreply@bowlneba.com",
     "AppPassword": "",
     "ReplyToAddress": "website@bowlneba.com"
   },
+
   "JwtSettings": {
     "Issuer": "https://api.bowlneba.com",
     "Audience": "https://bowlneba.com",
@@ -57,9 +78,11 @@
     "AccessTokenExpiryMinutes": 15,
     "RefreshTokenExpiryDays": 7
   },
+
   "RateLimiting": {
     "PermitLimit": 100,
     "WindowSeconds": 60
   },
+
   "AllowedHosts": "*"
 }

--- a/src/Neba.Website.Server/FeatureManagement/FeatureManagementConfiguration.cs
+++ b/src/Neba.Website.Server/FeatureManagement/FeatureManagementConfiguration.cs
@@ -1,0 +1,20 @@
+using Microsoft.FeatureManagement;
+
+using Neba.Api.Contracts.FeatureManagement;
+
+namespace Neba.Website.Server.FeatureManagement;
+
+internal static class FeatureManagementConfiguration
+{
+    extension(WebApplicationBuilder builder)
+    {
+        public WebApplicationBuilder AddFeatureManagement()
+        {
+            builder.Services
+                .AddFeatureManagement(builder.Configuration.GetSection("FeatureManagement"))
+                .AddFeatureFilter<AllowedEmailFilter>();
+
+            return builder;
+        }
+    }
+}

--- a/src/Neba.Website.Server/History/Champions/BowlerTitlesModal.razor.css
+++ b/src/Neba.Website.Server/History/Champions/BowlerTitlesModal.razor.css
@@ -29,7 +29,7 @@
     font-weight: 700;
     color: var(--t-ink);
     margin: 0;
-    word-break: break-word;
+    overflow-wrap: anywhere;
 }
 
 .modal-summary-inline {
@@ -91,7 +91,7 @@
     font-size: 1rem;
     font-weight: 600;
     color: var(--t-ink);
-    word-break: break-word;
+    overflow-wrap: anywhere;
 }
 
 /* Modal body */

--- a/src/Neba.Website.Server/History/Champions/TitleCountView.razor.css
+++ b/src/Neba.Website.Server/History/Champions/TitleCountView.razor.css
@@ -139,7 +139,7 @@
     font-size: 0.9rem;
     font-weight: 600;
     display: block;
-    word-break: break-word;
+    overflow-wrap: anywhere;
 }
 
 .bowler-card__count {

--- a/src/Neba.Website.Server/History/Champions/YearView.razor.css
+++ b/src/Neba.Website.Server/History/Champions/YearView.razor.css
@@ -98,7 +98,7 @@
 
 .col-champs {
     color: var(--t-ink);
-    word-break: break-word;
+    overflow-wrap: anywhere;
 }
 
 /* Champion links */

--- a/src/Neba.Website.Server/Neba.Website.Server.csproj
+++ b/src/Neba.Website.Server/Neba.Website.Server.csproj
@@ -8,6 +8,7 @@
     <PackageReference Include="Blazor-ApexCharts" />
     <PackageReference Include="ErrorOr" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" />
+    <PackageReference Include="Microsoft.FeatureManagement.AspNetCore" />
     <PackageReference Include="Newtonsoft.Json" />
     <PackageReference Include="Refit.HttpClientFactory" />
     <PackageReference Include="UnitsNet" />

--- a/src/Neba.Website.Server/Program.cs
+++ b/src/Neba.Website.Server/Program.cs
@@ -3,6 +3,7 @@ using ApexCharts;
 using Neba.Website.Server;
 using Neba.Website.Server.Account;
 using Neba.Website.Server.Clock;
+using Neba.Website.Server.FeatureManagement;
 using Neba.Website.Server.Maps;
 using Neba.Website.Server.Services;
 using Neba.Website.Server.Stats;
@@ -11,7 +12,9 @@ using Neba.Website.Server.Tournaments;
 var builder = WebApplication.CreateBuilder(args);
 
 // Add service defaults & Aspire client integrations.
-builder.AddServiceDefaults();
+builder
+    .AddServiceDefaults()
+    .AddFeatureManagement();
 
 builder.Services.AddApiServices(builder.Configuration);
 builder.Services.AddMaps(builder.Configuration);

--- a/src/Neba.Website.Server/Sponsors/SponsorDetail.razor.css
+++ b/src/Neba.Website.Server/Sponsors/SponsorDetail.razor.css
@@ -246,7 +246,7 @@
     color: var(--neba-gray-700);
     box-shadow: var(--neba-shadow-card);
     white-space: pre-wrap;
-    word-break: break-word;
+    overflow-wrap: anywhere;
     margin: 0;
 }
 

--- a/src/Neba.Website.Server/Tournaments/Schedule/TournamentLogoTile.razor.css
+++ b/src/Neba.Website.Server/Tournaments/Schedule/TournamentLogoTile.razor.css
@@ -33,7 +33,7 @@
     color: white;
     text-align: center;
     line-height: 1.1;
-    word-break: break-word;
+    overflow-wrap: anywhere;
 }
 
 .tournament-logo-tile__year {

--- a/src/Neba.Website.Server/appsettings.json
+++ b/src/Neba.Website.Server/appsettings.json
@@ -10,6 +10,21 @@
     "BaseUrl": "http://api"
   },
 
+  "FeatureManagement": {
+    "UserRegistration": {
+      "EnabledFor": [
+        {
+          "Name": "AllowedEmail",
+          "Parameters": {
+            "AllowedEmails": [
+              "tech@bowlneba.com"
+            ]
+          }
+        }
+      ]
+    }
+  },
+
   "AzureMaps": {
     "AccountId": "",
     "SubscriptionKey": ""

--- a/tests/Neba.Api.Tests/Contracts/FeatureManagement/AllowedEmailFilterTests.cs
+++ b/tests/Neba.Api.Tests/Contracts/FeatureManagement/AllowedEmailFilterTests.cs
@@ -11,6 +11,34 @@ public sealed class AllowedEmailFilterTests
 {
     private readonly AllowedEmailFilter _filter = new();
 
+#nullable disable
+    [Fact(DisplayName = "EvaluateAsync should throw when featureFilterContext is null")]
+    public async Task EvaluateAsync_ShouldThrow_WhenFeatureFilterContextIsNull()
+    {
+        // Arrange
+        var appContext = new AllowedEmailContext { Email = "allowed@bowlneba.com" };
+
+        // Act
+        var act = () => _filter.EvaluateAsync(null, appContext);
+
+        // Assert
+        await Should.ThrowAsync<ArgumentNullException>(act);
+    }
+
+    [Fact(DisplayName = "EvaluateAsync should throw when appContext is null")]
+    public async Task EvaluateAsync_ShouldThrow_WhenAppContextIsNull()
+    {
+        // Arrange
+        var featureFilterContext = CreateFeatureFilterContext(["allowed@bowlneba.com"]);
+
+        // Act
+        var act = () => _filter.EvaluateAsync(featureFilterContext, null);
+
+        // Assert
+        await Should.ThrowAsync<ArgumentNullException>(act);
+    }
+#nullable enable
+
     [Fact(DisplayName = "EvaluateAsync should return false when email is null")]
     public async Task EvaluateAsync_ShouldReturnFalse_WhenEmailIsNull()
     {

--- a/tests/Neba.Api.Tests/Contracts/FeatureManagement/AllowedEmailFilterTests.cs
+++ b/tests/Neba.Api.Tests/Contracts/FeatureManagement/AllowedEmailFilterTests.cs
@@ -1,5 +1,6 @@
 using Microsoft.Extensions.Configuration;
 using Microsoft.FeatureManagement;
+
 using Neba.Api.Contracts.FeatureManagement;
 using Neba.TestFactory.Attributes;
 

--- a/tests/Neba.Api.Tests/Contracts/FeatureManagement/AllowedEmailFilterTests.cs
+++ b/tests/Neba.Api.Tests/Contracts/FeatureManagement/AllowedEmailFilterTests.cs
@@ -1,0 +1,115 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.FeatureManagement;
+using Neba.Api.Contracts.FeatureManagement;
+using Neba.TestFactory.Attributes;
+
+namespace Neba.Api.Tests.Contracts.FeatureManagement;
+
+[UnitTest]
+[Component("Api.Contracts")]
+public sealed class AllowedEmailFilterTests
+{
+    private readonly AllowedEmailFilter _filter = new();
+
+    [Fact(DisplayName = "EvaluateAsync should return false when email is null")]
+    public async Task EvaluateAsync_ShouldReturnFalse_WhenEmailIsNull()
+    {
+#nullable disable
+        // Arrange
+        var featureFilterContext = CreateFeatureFilterContext(["allowed@bowlneba.com"]);
+        var appContext = new AllowedEmailContext { Email = null };
+
+        // Act
+        var result = await _filter.EvaluateAsync(featureFilterContext, appContext);
+
+        // Assert
+        result.ShouldBeFalse();
+#nullable enable
+    }
+
+    [Fact(DisplayName = "EvaluateAsync should return false when email is empty")]
+    public async Task EvaluateAsync_ShouldReturnFalse_WhenEmailIsEmpty()
+    {
+        // Arrange
+        var featureFilterContext = CreateFeatureFilterContext(["allowed@bowlneba.com"]);
+        var appContext = new AllowedEmailContext { Email = string.Empty };
+
+        // Act
+        var result = await _filter.EvaluateAsync(featureFilterContext, appContext);
+
+        // Assert
+        result.ShouldBeFalse();
+    }
+
+    [Fact(DisplayName = "EvaluateAsync should return true when email is in the allowed list")]
+    public async Task EvaluateAsync_ShouldReturnTrue_WhenEmailIsInAllowedList()
+    {
+        // Arrange
+        const string email = "allowed@bowlneba.com";
+        var featureFilterContext = CreateFeatureFilterContext([email, "other@bowlneba.com"]);
+        var appContext = new AllowedEmailContext { Email = email };
+
+        // Act
+        var result = await _filter.EvaluateAsync(featureFilterContext, appContext);
+
+        // Assert
+        result.ShouldBeTrue();
+    }
+
+    [Fact(DisplayName = "EvaluateAsync should return false when email is not in the allowed list")]
+    public async Task EvaluateAsync_ShouldReturnFalse_WhenEmailIsNotInAllowedList()
+    {
+        // Arrange
+        var featureFilterContext = CreateFeatureFilterContext(["allowed@bowlneba.com"]);
+        var appContext = new AllowedEmailContext { Email = "notallowed@bowlneba.com" };
+
+        // Act
+        var result = await _filter.EvaluateAsync(featureFilterContext, appContext);
+
+        // Assert
+        result.ShouldBeFalse();
+    }
+
+    [Fact(DisplayName = "EvaluateAsync should return false when the allowed list is empty")]
+    public async Task EvaluateAsync_ShouldReturnFalse_WhenAllowedListIsEmpty()
+    {
+        // Arrange
+        var featureFilterContext = CreateFeatureFilterContext([]);
+        var appContext = new AllowedEmailContext { Email = "allowed@bowlneba.com" };
+
+        // Act
+        var result = await _filter.EvaluateAsync(featureFilterContext, appContext);
+
+        // Assert
+        result.ShouldBeFalse();
+    }
+
+    [Fact(DisplayName = "EvaluateAsync should return false when no filter settings are configured")]
+    public async Task EvaluateAsync_ShouldReturnFalse_WhenNoParametersAreConfigured()
+    {
+        // Arrange
+        var featureFilterContext = new FeatureFilterEvaluationContext
+        {
+            Parameters = new ConfigurationBuilder().Build(),
+        };
+        var appContext = new AllowedEmailContext { Email = "allowed@bowlneba.com" };
+
+        // Act
+        var result = await _filter.EvaluateAsync(featureFilterContext, appContext);
+
+        // Assert
+        result.ShouldBeFalse();
+    }
+
+    private static FeatureFilterEvaluationContext CreateFeatureFilterContext(IReadOnlyList<string> allowedEmails)
+    {
+        var configurationData = allowedEmails
+            .Select((email, index) => new KeyValuePair<string, string?>($"AllowedEmails:{index}", email));
+
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(configurationData)
+            .Build();
+
+        return new FeatureFilterEvaluationContext { Parameters = configuration };
+    }
+}

--- a/tests/Neba.Api.Tests/Contracts/FeatureManagement/AllowedEmailFilterTests.cs
+++ b/tests/Neba.Api.Tests/Contracts/FeatureManagement/AllowedEmailFilterTests.cs
@@ -20,10 +20,10 @@ public sealed class AllowedEmailFilterTests
         var appContext = new AllowedEmailContext { Email = "allowed@bowlneba.com" };
 
         // Act
-        var act = () => _filter.EvaluateAsync(null, appContext);
+        Task<bool> Act() => _filter.EvaluateAsync(null, appContext);
 
         // Assert
-        await Should.ThrowAsync<ArgumentNullException>(act);
+        await Should.ThrowAsync<ArgumentNullException>((Func<Task<bool>>)Act);
     }
 
     [Fact(DisplayName = "EvaluateAsync should throw when appContext is null")]
@@ -33,10 +33,10 @@ public sealed class AllowedEmailFilterTests
         var featureFilterContext = CreateFeatureFilterContext(["allowed@bowlneba.com"]);
 
         // Act
-        var act = () => _filter.EvaluateAsync(featureFilterContext, null);
+        Task<bool> Act() => _filter.EvaluateAsync(featureFilterContext, null);
 
         // Assert
-        await Should.ThrowAsync<ArgumentNullException>(act);
+        await Should.ThrowAsync<ArgumentNullException>((Func<Task<bool>>)Act);
     }
 #nullable enable
 

--- a/tests/Neba.Api.Tests/Contracts/FeatureManagement/AllowedEmailFilterTests.cs
+++ b/tests/Neba.Api.Tests/Contracts/FeatureManagement/AllowedEmailFilterTests.cs
@@ -85,6 +85,20 @@ public sealed class AllowedEmailFilterTests
         result.ShouldBeTrue();
     }
 
+    [Fact(DisplayName = "EvaluateAsync should return true when email matches the allowed list with different casing")]
+    public async Task EvaluateAsync_ShouldReturnTrue_WhenEmailMatchesAllowedListWithDifferentCasing()
+    {
+        // Arrange
+        var featureFilterContext = CreateFeatureFilterContext(["allowed@bowlneba.com"]);
+        var appContext = new AllowedEmailContext { Email = "ALLOWED@BowlNeba.com" };
+
+        // Act
+        var result = await _filter.EvaluateAsync(featureFilterContext, appContext);
+
+        // Assert
+        result.ShouldBeTrue();
+    }
+
     [Fact(DisplayName = "EvaluateAsync should return false when email is not in the allowed list")]
     public async Task EvaluateAsync_ShouldReturnFalse_WhenEmailIsNotInAllowedList()
     {

--- a/tests/Neba.Api.Tests/Security/Register/RegisterEndpointTests.cs
+++ b/tests/Neba.Api.Tests/Security/Register/RegisterEndpointTests.cs
@@ -2,6 +2,9 @@ using ErrorOr;
 
 using FastEndpoints;
 
+using Microsoft.FeatureManagement;
+
+using Neba.Api.Contracts.FeatureManagement;
 using Neba.Api.Contracts.Security.Register;
 using Neba.Api.Security.Register;
 using Neba.TestFactory.Attributes;
@@ -30,7 +33,9 @@ public sealed class RegisterEndpointTests
                 ct))
             .ReturnsAsync(userId);
 
-        var endpoint = Factory.Create<RegisterEndpoint>(commandHandlerMock.Object);
+        var featureManagerMock = CreateFeatureManagerMock(isEnabled: true);
+
+        var endpoint = Factory.Create<RegisterEndpoint>(commandHandlerMock.Object, featureManagerMock.Object);
 
         // Act — Send.CreatedAtAsync requires LinkGenerator, which Factory.Create does not provide.
         // The strict mock verifies the command mapping; the LinkGenerator exception confirms the success branch was taken.
@@ -53,7 +58,9 @@ public sealed class RegisterEndpointTests
             .Setup(h => h.HandleAsync(It.IsAny<RegisterCommand>(), ct))
             .ReturnsAsync(RegisterErrors.DuplicateEmail);
 
-        var endpoint = Factory.Create<RegisterEndpoint>(commandHandlerMock.Object);
+        var featureManagerMock = CreateFeatureManagerMock(isEnabled: true);
+
+        var endpoint = Factory.Create<RegisterEndpoint>(commandHandlerMock.Object, featureManagerMock.Object);
 
         // Act
         await endpoint.HandleAsync(request, ct);
@@ -74,7 +81,9 @@ public sealed class RegisterEndpointTests
             .Setup(h => h.HandleAsync(It.IsAny<RegisterCommand>(), ct))
             .ReturnsAsync(Error.Validation("Register.WeakPassword", "Password does not meet requirements."));
 
-        var endpoint = Factory.Create<RegisterEndpoint>(commandHandlerMock.Object);
+        var featureManagerMock = CreateFeatureManagerMock(isEnabled: true);
+
+        var endpoint = Factory.Create<RegisterEndpoint>(commandHandlerMock.Object, featureManagerMock.Object);
 
         // Act
         await endpoint.HandleAsync(request, ct);
@@ -83,16 +92,47 @@ public sealed class RegisterEndpointTests
         endpoint.HttpContext.Response.StatusCode.ShouldBe(422);
     }
 
+    [Fact(DisplayName = "HandleAsync should return 404 and not invoke the command handler when the UserRegistration feature is disabled")]
+    public async Task HandleAsync_ShouldReturn404AndNotInvokeCommandHandler_WhenFeatureIsDisabled()
+    {
+        // Arrange
+        var request = RegisterRequestFactory.Create();
+        var ct = TestContext.Current.CancellationToken;
+
+        var commandHandlerMock = new Mock<NebaMessaging.ICommandHandler<RegisterCommand, Ulid>>(MockBehavior.Strict);
+
+        var featureManagerMock = CreateFeatureManagerMock(isEnabled: false);
+
+        var endpoint = Factory.Create<RegisterEndpoint>(commandHandlerMock.Object, featureManagerMock.Object);
+
+        // Act
+        await endpoint.HandleAsync(request, ct);
+
+        // Assert — strict command handler mock has no setups, so any invocation would throw
+        endpoint.HttpContext.Response.StatusCode.ShouldBe(404);
+    }
+
     [Fact(DisplayName = "Configure should register anonymous POST route containing 'register'")]
     public void Configure_ShouldRegisterAnonymousPostRoute_ContainingRegister()
     {
         // Arrange
         var commandHandlerMock = new Mock<NebaMessaging.ICommandHandler<RegisterCommand, Ulid>>(MockBehavior.Strict);
-        var endpoint = Factory.Create<RegisterEndpoint>(commandHandlerMock.Object);
+        var featureManagerMock = CreateFeatureManagerMock(isEnabled: true);
+        var endpoint = Factory.Create<RegisterEndpoint>(commandHandlerMock.Object, featureManagerMock.Object);
 
         // Assert
         endpoint.Definition.Verbs.ShouldContain("POST");
         endpoint.Definition.Routes.ShouldContain(r => r.Contains("register"), "should include a 'register' route");
         endpoint.Definition.AnonymousVerbs.ShouldNotBeEmpty();
+    }
+
+    private static Mock<IFeatureManager> CreateFeatureManagerMock(bool isEnabled)
+    {
+        var featureManagerMock = new Mock<IFeatureManager>(MockBehavior.Strict);
+        featureManagerMock
+            .Setup(f => f.IsEnabledAsync(FeatureFlags.UserRegistration, It.IsAny<AllowedEmailContext>()))
+            .ReturnsAsync(isEnabled);
+
+        return featureManagerMock;
     }
 }

--- a/tests/Neba.Api.Tests/Security/Register/RegisterEndpointTests.cs
+++ b/tests/Neba.Api.Tests/Security/Register/RegisterEndpointTests.cs
@@ -1,3 +1,6 @@
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+
 using ErrorOr;
 
 using FastEndpoints;
@@ -112,6 +115,64 @@ public sealed class RegisterEndpointTests
         endpoint.HttpContext.Response.StatusCode.ShouldBe(404);
     }
 
+    [Fact(DisplayName = "HandleAsync should pass the caller's JWT email claim to feature evaluation and take the success branch when the caller is allow-listed")]
+    public async Task HandleAsync_ShouldPassCallerEmailToFeatureEvaluationAndSucceed_WhenCallerIsAllowListed()
+    {
+        // Arrange
+        const string callerEmail = "allowed@bowlneba.com";
+        var userId = Ulid.NewUlid();
+        var request = RegisterRequestFactory.Create();
+        var ct = TestContext.Current.CancellationToken;
+
+        var commandHandlerMock = new Mock<NebaMessaging.ICommandHandler<RegisterCommand, Ulid>>(MockBehavior.Strict);
+        commandHandlerMock
+            .Setup(h => h.HandleAsync(
+                It.Is<RegisterCommand>(c => c.Email == request.Input.Email && c.Password == request.Input.Password),
+                ct))
+            .ReturnsAsync(userId);
+
+        var featureManagerMock = CreateFeatureManagerMock(isEnabled: true, expectedEmail: callerEmail);
+
+        var endpoint = Factory.Create<RegisterEndpoint>(commandHandlerMock.Object, featureManagerMock.Object);
+        endpoint.HttpContext.User = new ClaimsPrincipal(new ClaimsIdentity(
+        [
+            new Claim(JwtRegisteredClaimNames.Email, callerEmail),
+        ]));
+
+        // Act — Send.CreatedAtAsync requires LinkGenerator, which Factory.Create does not provide.
+        // The strict mocks verify the caller's email reached feature evaluation and the command handler.
+        var exception = await Should.ThrowAsync<InvalidOperationException>(
+            () => endpoint.HandleAsync(request, ct));
+
+        // Assert
+        exception.Message.ShouldContain("LinkGenerator");
+    }
+
+    [Fact(DisplayName = "HandleAsync should pass the caller's JWT email claim to feature evaluation and return 404 when the caller is not allow-listed")]
+    public async Task HandleAsync_ShouldPassCallerEmailToFeatureEvaluationAndReturn404_WhenCallerIsNotAllowListed()
+    {
+        // Arrange
+        const string callerEmail = "notallowed@bowlneba.com";
+        var request = RegisterRequestFactory.Create();
+        var ct = TestContext.Current.CancellationToken;
+
+        var commandHandlerMock = new Mock<NebaMessaging.ICommandHandler<RegisterCommand, Ulid>>(MockBehavior.Strict);
+
+        var featureManagerMock = CreateFeatureManagerMock(isEnabled: false, expectedEmail: callerEmail);
+
+        var endpoint = Factory.Create<RegisterEndpoint>(commandHandlerMock.Object, featureManagerMock.Object);
+        endpoint.HttpContext.User = new ClaimsPrincipal(new ClaimsIdentity(
+        [
+            new Claim(JwtRegisteredClaimNames.Email, callerEmail),
+        ]));
+
+        // Act
+        await endpoint.HandleAsync(request, ct);
+
+        // Assert — strict command handler mock has no setups, so any invocation would throw
+        endpoint.HttpContext.Response.StatusCode.ShouldBe(404);
+    }
+
     [Fact(DisplayName = "Configure should register anonymous POST route containing 'register'")]
     public void Configure_ShouldRegisterAnonymousPostRoute_ContainingRegister()
     {
@@ -126,11 +187,13 @@ public sealed class RegisterEndpointTests
         endpoint.Definition.AnonymousVerbs.ShouldNotBeEmpty();
     }
 
-    private static Mock<IFeatureManager> CreateFeatureManagerMock(bool isEnabled)
+    private static Mock<IFeatureManager> CreateFeatureManagerMock(bool isEnabled, string? expectedEmail = null)
     {
         var featureManagerMock = new Mock<IFeatureManager>(MockBehavior.Strict);
         featureManagerMock
-            .Setup(f => f.IsEnabledAsync(FeatureFlags.UserRegistration, It.IsAny<AllowedEmailContext>()))
+            .Setup(f => f.IsEnabledAsync(
+                FeatureFlags.UserRegistration,
+                It.Is<AllowedEmailContext>(c => c.Email == expectedEmail)))
             .ReturnsAsync(isEnabled);
 
         return featureManagerMock;

--- a/tests/Neba.Api.Tests/Security/Register/RegisterSummaryTests.cs
+++ b/tests/Neba.Api.Tests/Security/Register/RegisterSummaryTests.cs
@@ -27,7 +27,7 @@ public sealed class RegisterSummaryTests
         summary.Description.ShouldNotBeNullOrWhiteSpace();
     }
 
-    [Fact(DisplayName = "Constructor should register 201, 409, and 422 responses")]
+    [Fact(DisplayName = "Constructor should register 201, 404, 409, and 422 responses")]
     public void Constructor_ShouldRegisterExpectedResponses()
     {
         // Arrange & Act
@@ -35,6 +35,7 @@ public sealed class RegisterSummaryTests
 
         // Assert
         summary.Responses.ShouldContainKey(201);
+        summary.Responses.ShouldContainKey(404);
         summary.Responses.ShouldContainKey(409);
         summary.Responses.ShouldContainKey(422);
     }


### PR DESCRIPTION
## Summary

- **Feature Flagging**: adopts `Microsoft.FeatureManagement` in both `Neba.Api` and `Neba.Website.Server`, backed by `appsettings.json` (no Azure App Configuration yet).
- Adds a shared `AllowedEmail` contextual feature filter and `FeatureFlags` constants in `Neba.Api.Contracts` so the same flag/filter can be evaluated identically from both processes.
- Gates the `POST register` endpoint behind a new `UserRegistration` flag: only a caller whose JWT `email` claim is on the allow-list (`tech@bowlneba.com`) can invoke it; everyone else gets a 404. `AllowAnonymous()` is unchanged — this is an interim stopgap until real self-service registration rules exist.
- Documents the design rationale and phased approach in `docs/plans/feature-flagging.md`.

## Context

There's no UI for user registration yet, so the endpoint needs to stay reachable without requiring a new authorization policy while remaining effectively private. The chosen approach reads the caller's JWT `email` claim if a bearer token happens to be present (authentication still runs under `AllowAnonymous()`, only authorization is skipped) and compares it against an allow-list, returning 404 (not 403) to avoid revealing the endpoint exists.

## What Changed

### Contracts
- `src/Neba.Api.Contracts/FeatureManagement/FeatureFlags.cs` — `UserRegistration` flag name constant.
- `src/Neba.Api.Contracts/FeatureManagement/AllowedEmailFilter.cs` — `IContextualFeatureFilter<AllowedEmailContext>` (`[FilterAlias("AllowedEmail")]`); treats a null/empty email as never matching, otherwise does a case-insensitive allow-list check.
- `src/Neba.Api.Contracts/FeatureManagement/AllowedEmailContext.cs` — carries the caller's (nullable) email into filter evaluation.
- `src/Neba.Api.Contracts/FeatureManagement/AllowedEmailFilterSettings.cs` — `AllowedEmails` collection bound from `FeatureManagement:<Flag>:EnabledFor:Parameters`.
- `Neba.Api.Contracts.csproj` — new `Microsoft.FeatureManagement` package reference (core package only, no ASP.NET Core dependency).

### Infrastructure
- `src/Neba.Api/Infrastructure/FeatureManagement/FeatureManagementConfiguration.cs` — `AddFeatureManagement()` builder extension; binds the `FeatureManagement` config section and registers `AllowedEmailFilter`.
- `src/Neba.Website.Server/FeatureManagement/FeatureManagementConfiguration.cs` — equivalent registration for the Website process, reusing the same shared filter.

### API
- `src/Neba.Api/Program.cs` — wires `.AddFeatureManagement()` into the builder chain.
- `src/Neba.Api/Security/Register/RegisterEndpoint.cs` — reads the caller's `email` claim, evaluates `FeatureFlags.UserRegistration` via `IFeatureManager.IsEnabledAsync`, and short-circuits to `Send.NotFoundAsync` when disabled/no match before dispatching `RegisterCommand`.
- `src/Neba.Api/Security/Register/RegisterSummary.cs` — documents the new 404 response for OpenAPI.
- `src/Neba.Api/Neba.Api.csproj` — new `Microsoft.FeatureManagement.AspNetCore` package reference.
- `src/Neba.Api/appsettings.json` — `FeatureManagement:UserRegistration` section with the `AllowedEmail` filter and initial allow-list.

### Blazor (`Neba.Website.Server`)
- `src/Neba.Website.Server/Program.cs` — wires `.AddFeatureManagement()` into the builder chain (no UI usage yet — registration only, so the flag can be reused from a page later without a second implementation).
- `src/Neba.Website.Server/Neba.Website.Server.csproj` — new `Microsoft.FeatureManagement.AspNetCore` package reference.
- `src/Neba.Website.Server/appsettings.json` — same `FeatureManagement:UserRegistration` section, kept in sync by hand with the API's.

### Tests
- `tests/Neba.Api.Tests/.../FeatureManagement/AllowedEmailFilterTests.cs` — covers matching email, non-matching email, case-insensitive match, and empty allow-list.
- `tests/Neba.Api.Tests/.../Security/Register/RegisterEndpointTests.cs` — new cases: no bearer token → 404 without invoking the command handler; token present but email not allow-listed → 404; token present with allow-listed email → falls through to existing success/error branches (`MockBehavior.Strict` on the command handler proves it's never called in the blocked cases).
- `RegisterSummaryTests.cs` — updated for the new 404 response documentation.

### CI / Tooling
- `.claude/settings.json` — allowlists an `ilspycmd` invocation used to inspect `Microsoft.FeatureManagement.FeatureFilterEvaluationContext` during implementation.

### Docs
- `docs/plans/feature-flagging.md` — design plan covering the gating mechanism, package/config setup, filter/flag sharing rationale, and deferred follow-ups (UI feature gating ergonomics, Azure App Configuration).

## Test Plan

- [ ] `dotnet test --filter "Category=Unit"` — all unit tests pass
- [ ] `dotnet test --filter "Component=FeatureManagement"` — `AllowedEmailFilterTests` pass
- [ ] `dotnet test --filter "Component=Security"` — `RegisterEndpointTests` / `RegisterSummaryTests` pass
- [ ] Call `POST /register` with no bearer token and verify 404
- [ ] Call `POST /register` with a token for a non-allow-listed email and verify 404
- [ ] Call `POST /register` with a token for `tech@bowlneba.com` and verify normal registration behavior (201/409/422)

## Deferred

- No UI for registration or flag toggling in `Neba.Website.Server` yet — registration wiring only.
- No Azure App Configuration — flags require a redeploy to change; the allow-list must be kept in sync by hand between `Neba.Api` and `Neba.Website.Server` `appsettings.json`.
- No `<FeatureGate>`-style Blazor component or client-side (WASM) flag support.
